### PR TITLE
feat(rag): implement RAG knowledge base for AI assistant

### DIFF
--- a/backend/apps/ai_assistant/tools/rag_tools.py
+++ b/backend/apps/ai_assistant/tools/rag_tools.py
@@ -1,0 +1,339 @@
+"""RAG tools for the AI assistant.
+
+These tools allow the AI to search the knowledge base containing:
+- Past simulation results (fractal dimensions, parameters, metrics)
+- FRAKTAL analysis results
+- Scientific documentation about DLA, CCA, fractal analysis
+"""
+
+import logging
+from typing import Any
+
+from .decorators import tool
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    name="search_knowledge_base",
+    description="""Search the knowledge base for relevant information.
+
+Use this tool to find:
+- Results from past simulations (fractal dimensions, parameters, etc.)
+- FRAKTAL analysis results
+- Scientific literature about DLA, CCA, and fractal analysis
+
+The search uses semantic similarity, so natural language queries work well.
+
+Examples:
+- "What Df values have I seen for DLA with 1000 particles?"
+- "How does sticking probability affect fractal dimension?"
+- "Find information about cluster-cluster aggregation"
+- "What were the results of my recent analyses?"
+""",
+    category="knowledge",
+    requires_project=False,
+    is_async=False,
+)
+def search_knowledge_base_handler(
+    query: str,
+    source_type: str | None = None,
+    max_results: int = 5,
+    user: Any = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Search the RAG knowledge base.
+
+    Args:
+        query: Natural language search query.
+        source_type: Filter by type: simulation, analysis, scientific_doc.
+        max_results: Maximum results to return (1-10).
+        user: The authenticated user (auto-injected).
+
+    Returns:
+        Dictionary with search results.
+    """
+    if not user:
+        return {
+            "success": False,
+            "error": {
+                "error_type": "AuthenticationError",
+                "message": "User context required for knowledge base search",
+            },
+        }
+
+    # Validate max_results
+    max_results = min(max(1, max_results), 10)
+
+    # Parse source type filter
+    source_types = None
+    if source_type:
+        valid_types = ["simulation", "analysis", "scientific_doc"]
+        if source_type in valid_types:
+            source_types = [source_type]
+        else:
+            return {
+                "success": False,
+                "error": {
+                    "error_type": "ValidationError",
+                    "message": f"Invalid source_type. Must be one of: {valid_types}",
+                },
+            }
+
+    try:
+        from apps.rag.services.search_service import get_search_service
+
+        search_service = get_search_service()
+        results = search_service.search(
+            query=query,
+            user=user,
+            k=max_results,
+            source_types=source_types,
+        )
+
+        if not results:
+            return {
+                "success": True,
+                "found": False,
+                "message": "No relevant results found in the knowledge base.",
+                "results": [],
+            }
+
+        return {
+            "success": True,
+            "found": True,
+            "count": len(results),
+            "results": [r.to_dict() for r in results],
+        }
+
+    except Exception as e:
+        logger.exception(f"Knowledge base search failed: {e}")
+        return {
+            "success": False,
+            "error": {
+                "error_type": "SearchError",
+                "message": f"Knowledge base search failed: {str(e)}",
+            },
+        }
+
+
+@tool(
+    name="get_simulation_insights",
+    description="""Get aggregated insights and statistics from past simulations.
+
+Use this to answer questions like:
+- "What's the typical Df range for DLA simulations?"
+- "How many simulations have I run with a specific algorithm?"
+- "Show statistics for simulations with >1000 particles"
+
+This tool provides aggregated statistics rather than individual results.
+For finding specific simulations, use search_knowledge_base instead.
+""",
+    category="knowledge",
+    requires_project=False,
+    is_async=False,
+)
+def get_simulation_insights_handler(
+    algorithm: str | None = None,
+    min_particles: int | None = None,
+    user: Any = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Get statistical insights from indexed simulations.
+
+    Args:
+        algorithm: Filter by algorithm (dla, cca, ballistic, etc.).
+        min_particles: Minimum particle count filter.
+        user: The authenticated user (auto-injected).
+
+    Returns:
+        Aggregated statistics and insights.
+    """
+    if not user:
+        return {
+            "success": False,
+            "error": {
+                "error_type": "AuthenticationError",
+                "message": "User context required",
+            },
+        }
+
+    try:
+        from apps.rag.models import IndexedDocument, DocumentSource, DocumentStatus
+        import statistics
+
+        # Query indexed simulations
+        queryset = IndexedDocument.objects.filter(
+            owner=user,
+            source_type=DocumentSource.SIMULATION,
+            status=DocumentStatus.READY,
+        )
+
+        # Apply filters via metadata
+        if algorithm:
+            queryset = queryset.filter(metadata__algorithm=algorithm.lower())
+
+        if min_particles:
+            queryset = queryset.filter(metadata__n_particles__gte=min_particles)
+
+        # Count and extract statistics
+        count = queryset.count()
+
+        if count == 0:
+            return {
+                "success": True,
+                "found": False,
+                "message": "No indexed simulations match the criteria.",
+                "filters_applied": {
+                    "algorithm": algorithm,
+                    "min_particles": min_particles,
+                },
+            }
+
+        # Extract Df values from metadata
+        df_values = [
+            doc.metadata.get("fractal_dimension")
+            for doc in queryset
+            if doc.metadata.get("fractal_dimension") is not None
+        ]
+
+        stats = {}
+        if df_values:
+            stats["fractal_dimension"] = {
+                "mean": round(statistics.mean(df_values), 4),
+                "std": round(statistics.stdev(df_values), 4) if len(df_values) > 1 else 0,
+                "min": round(min(df_values), 4),
+                "max": round(max(df_values), 4),
+                "count": len(df_values),
+            }
+
+        # Get algorithm distribution
+        algorithm_counts = {}
+        for doc in queryset:
+            alg = doc.metadata.get("algorithm", "unknown")
+            algorithm_counts[alg] = algorithm_counts.get(alg, 0) + 1
+
+        return {
+            "success": True,
+            "found": True,
+            "total_simulations": count,
+            "filters_applied": {
+                "algorithm": algorithm,
+                "min_particles": min_particles,
+            },
+            "statistics": stats,
+            "algorithm_distribution": algorithm_counts,
+        }
+
+    except Exception as e:
+        logger.exception(f"Failed to get simulation insights: {e}")
+        return {
+            "success": False,
+            "error": {
+                "error_type": "InternalError",
+                "message": f"Failed to get simulation insights: {str(e)}",
+            },
+        }
+
+
+@tool(
+    name="get_analysis_insights",
+    description="""Get aggregated insights from FRAKTAL analyses.
+
+Use this to understand patterns in your analysis results:
+- "What Df values have I measured?"
+- "How do my analyses compare across different images?"
+""",
+    category="knowledge",
+    requires_project=False,
+    is_async=False,
+)
+def get_analysis_insights_handler(
+    model: str | None = None,
+    user: Any = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Get statistical insights from indexed analyses.
+
+    Args:
+        model: Filter by FRAKTAL model (granulated_2012, voxel_2018).
+        user: The authenticated user (auto-injected).
+
+    Returns:
+        Aggregated statistics and insights.
+    """
+    if not user:
+        return {
+            "success": False,
+            "error": {
+                "error_type": "AuthenticationError",
+                "message": "User context required",
+            },
+        }
+
+    try:
+        from apps.rag.models import IndexedDocument, DocumentSource, DocumentStatus
+        import statistics
+
+        # Query indexed analyses
+        queryset = IndexedDocument.objects.filter(
+            owner=user,
+            source_type=DocumentSource.ANALYSIS,
+            status=DocumentStatus.READY,
+        )
+
+        # Apply model filter
+        if model:
+            queryset = queryset.filter(metadata__model=model.lower())
+
+        count = queryset.count()
+
+        if count == 0:
+            return {
+                "success": True,
+                "found": False,
+                "message": "No indexed analyses match the criteria.",
+                "filters_applied": {"model": model},
+            }
+
+        # Extract Df values from metadata
+        df_values = [
+            doc.metadata.get("fractal_dimension")
+            for doc in queryset
+            if doc.metadata.get("fractal_dimension") is not None
+        ]
+
+        stats = {}
+        if df_values:
+            stats["fractal_dimension"] = {
+                "mean": round(statistics.mean(df_values), 4),
+                "std": round(statistics.stdev(df_values), 4) if len(df_values) > 1 else 0,
+                "min": round(min(df_values), 4),
+                "max": round(max(df_values), 4),
+                "count": len(df_values),
+            }
+
+        # Get model distribution
+        model_counts = {}
+        for doc in queryset:
+            m = doc.metadata.get("model", "unknown")
+            model_counts[m] = model_counts.get(m, 0) + 1
+
+        return {
+            "success": True,
+            "found": True,
+            "total_analyses": count,
+            "filters_applied": {"model": model},
+            "statistics": stats,
+            "model_distribution": model_counts,
+        }
+
+    except Exception as e:
+        logger.exception(f"Failed to get analysis insights: {e}")
+        return {
+            "success": False,
+            "error": {
+                "error_type": "InternalError",
+                "message": f"Failed to get analysis insights: {str(e)}",
+            },
+        }

--- a/backend/apps/ai_assistant/tools/registration.py
+++ b/backend/apps/ai_assistant/tools/registration.py
@@ -60,6 +60,13 @@ def register_all_tools(registry: ToolRegistry) -> None:
         run_fraktal_from_image_tool,
     )
 
+    # Import RAG knowledge base tools
+    from .rag_tools import (
+        get_analysis_insights_handler,
+        get_simulation_insights_handler,
+        search_knowledge_base_handler,
+    )
+
     # Utility tools
     registry.register(list_algorithms_tool)
     registry.register(get_project_info_tool)
@@ -92,5 +99,10 @@ def register_all_tools(registry: ToolRegistry) -> None:
     registry.register(compare_simulations_tool)
     registry.register(analyze_parametric_study_tool)
     registry.register(list_analyses_tool)
+
+    # RAG knowledge base tools
+    registry.register(search_knowledge_base_handler)
+    registry.register(get_simulation_insights_handler)
+    registry.register(get_analysis_insights_handler)
 
     logger.info(f"Registered {len(registry)} AI tools")

--- a/backend/apps/ai_assistant/tools/registration.py
+++ b/backend/apps/ai_assistant/tools/registration.py
@@ -60,12 +60,12 @@ def register_all_tools(registry: ToolRegistry) -> None:
         run_fraktal_from_image_tool,
     )
 
-    # Import RAG knowledge base tools
-    from .rag_tools import (
-        get_analysis_insights_handler,
-        get_simulation_insights_handler,
-        search_knowledge_base_handler,
-    )
+    # TODO: Enable RAG tools when pgvector is available (see docs/RAG_IMPLEMENTATION_STATUS.md)
+    # from .rag_tools import (
+    #     get_analysis_insights_handler,
+    #     get_simulation_insights_handler,
+    #     search_knowledge_base_handler,
+    # )
 
     # Utility tools
     registry.register(list_algorithms_tool)
@@ -100,9 +100,9 @@ def register_all_tools(registry: ToolRegistry) -> None:
     registry.register(analyze_parametric_study_tool)
     registry.register(list_analyses_tool)
 
-    # RAG knowledge base tools
-    registry.register(search_knowledge_base_handler)
-    registry.register(get_simulation_insights_handler)
-    registry.register(get_analysis_insights_handler)
+    # TODO: Enable RAG tools when pgvector is available (see docs/RAG_IMPLEMENTATION_STATUS.md)
+    # registry.register(search_knowledge_base_handler)
+    # registry.register(get_simulation_insights_handler)
+    # registry.register(get_analysis_insights_handler)
 
     logger.info(f"Registered {len(registry)} AI tools")

--- a/backend/apps/ai_assistant/views.py
+++ b/backend/apps/ai_assistant/views.py
@@ -59,6 +59,18 @@ NOTIFICATIONS:
 - Users can see their recent simulations in the sidebar
 - Tell users they will be notified when their simulation completes
 
+KNOWLEDGE BASE ACCESS:
+- You have access to a knowledge base containing:
+  - Results from the user's past simulations (fractal dimensions, parameters, etc.)
+  - FRAKTAL analysis results
+  - Scientific literature about DLA, CCA, and fractal analysis
+- Use the `search_knowledge_base` tool to find relevant information when users ask about:
+  - Expected values or typical ranges for Df, Rg, etc.
+  - Results from their past work
+  - How parameters affect outcomes
+- Use `get_simulation_insights` or `get_analysis_insights` for aggregated statistics
+- When providing information from the knowledge base, cite the source (e.g., "Based on your past DLA simulations...")
+
 When a user asks a question:
 1. Use the appropriate tool(s) to gather information
 2. Explain the results in a clear, helpful way

--- a/backend/apps/fractal_analysis/tasks.py
+++ b/backend/apps/fractal_analysis/tasks.py
@@ -320,13 +320,13 @@ def run_fraktal_auto_calibrate_task(self, analysis_id: str) -> dict:
         analysis.completed_at = timezone.now()
         analysis.save()
 
-        # Index analysis for RAG knowledge base (only if successful)
-        if analysis.status == AnalysisStatus.COMPLETED:
-            try:
-                from apps.rag.tasks import index_analysis_task
-                index_analysis_task.delay(str(analysis.id))
-            except Exception as e:
-                logger.warning(f"Failed to queue RAG indexing for analysis {analysis_id}: {e}")
+        # TODO: Enable RAG indexing when pgvector is available (see docs/RAG_IMPLEMENTATION_STATUS.md)
+        # if analysis.status == AnalysisStatus.COMPLETED:
+        #     try:
+        #         from apps.rag.tasks import index_analysis_task
+        #         index_analysis_task.delay(str(analysis.id))
+        #     except Exception as e:
+        #         logger.warning(f"Failed to queue RAG indexing for analysis {analysis_id}: {e}")
 
         logger.info(
             f"Auto-calibration {analysis_id} completed: best_dpo={best_dpo:.1f}nm, "
@@ -490,13 +490,13 @@ def run_fraktal_analysis_task(self, analysis_id: str) -> dict:
         analysis.completed_at = timezone.now()
         analysis.save()
 
-        # Index analysis for RAG knowledge base (only if successful)
-        if analysis.status == AnalysisStatus.COMPLETED:
-            try:
-                from apps.rag.tasks import index_analysis_task
-                index_analysis_task.delay(str(analysis.id))
-            except Exception as e:
-                logger.warning(f"Failed to queue RAG indexing for analysis {analysis_id}: {e}")
+        # TODO: Enable RAG indexing when pgvector is available (see docs/RAG_IMPLEMENTATION_STATUS.md)
+        # if analysis.status == AnalysisStatus.COMPLETED:
+        #     try:
+        #         from apps.rag.tasks import index_analysis_task
+        #         index_analysis_task.delay(str(analysis.id))
+        #     except Exception as e:
+        #         logger.warning(f"Failed to queue RAG indexing for analysis {analysis_id}: {e}")
 
         logger.info(
             f"FRAKTAL analysis {analysis_id} completed: Df={result.df:.4f}, "

--- a/backend/apps/fractal_analysis/tasks.py
+++ b/backend/apps/fractal_analysis/tasks.py
@@ -320,6 +320,14 @@ def run_fraktal_auto_calibrate_task(self, analysis_id: str) -> dict:
         analysis.completed_at = timezone.now()
         analysis.save()
 
+        # Index analysis for RAG knowledge base (only if successful)
+        if analysis.status == AnalysisStatus.COMPLETED:
+            try:
+                from apps.rag.tasks import index_analysis_task
+                index_analysis_task.delay(str(analysis.id))
+            except Exception as e:
+                logger.warning(f"Failed to queue RAG indexing for analysis {analysis_id}: {e}")
+
         logger.info(
             f"Auto-calibration {analysis_id} completed: best_dpo={best_dpo:.1f}nm, "
             f"Df={best_result.df:.4f}, npo={best_result.npo}, status={best_result.status}"
@@ -481,6 +489,14 @@ def run_fraktal_analysis_task(self, analysis_id: str) -> dict:
 
         analysis.completed_at = timezone.now()
         analysis.save()
+
+        # Index analysis for RAG knowledge base (only if successful)
+        if analysis.status == AnalysisStatus.COMPLETED:
+            try:
+                from apps.rag.tasks import index_analysis_task
+                index_analysis_task.delay(str(analysis.id))
+            except Exception as e:
+                logger.warning(f"Failed to queue RAG indexing for analysis {analysis_id}: {e}")
 
         logger.info(
             f"FRAKTAL analysis {analysis_id} completed: Df={result.df:.4f}, "

--- a/backend/apps/rag/__init__.py
+++ b/backend/apps/rag/__init__.py
@@ -1,0 +1,1 @@
+"""RAG (Retrieval-Augmented Generation) app for pyaglogen3D."""

--- a/backend/apps/rag/admin.py
+++ b/backend/apps/rag/admin.py
@@ -1,0 +1,137 @@
+"""Admin interface for RAG models."""
+
+from django.contrib import admin
+from django.utils.html import format_html
+
+from .models import IndexedDocument, DocumentChunk, DocumentStatus
+from .tasks import index_scientific_document_task
+
+
+@admin.register(IndexedDocument)
+class IndexedDocumentAdmin(admin.ModelAdmin):
+    """Admin for IndexedDocument model."""
+
+    list_display = [
+        "title_preview",
+        "source_type",
+        "status_badge",
+        "owner",
+        "is_global",
+        "chunk_count",
+        "created_at",
+    ]
+    list_filter = ["source_type", "status", "is_global"]
+    search_fields = ["title", "abstract", "metadata"]
+    readonly_fields = [
+        "id",
+        "content_hash",
+        "indexed_at",
+        "created_at",
+        "updated_at",
+        "chunk_count",
+    ]
+    ordering = ["-created_at"]
+
+    fieldsets = (
+        (None, {
+            "fields": ("title", "source_type", "source_id", "status", "error_message")
+        }),
+        ("Ownership", {
+            "fields": ("owner", "is_global")
+        }),
+        ("Scientific Document Info", {
+            "fields": ("authors", "year", "abstract", "url", "file"),
+            "classes": ("collapse",),
+        }),
+        ("Metadata", {
+            "fields": ("metadata",),
+            "classes": ("collapse",),
+        }),
+        ("System", {
+            "fields": ("id", "content_hash", "indexed_at", "created_at", "updated_at"),
+            "classes": ("collapse",),
+        }),
+    )
+
+    actions = ["reindex_selected", "mark_as_pending"]
+
+    def title_preview(self, obj: IndexedDocument) -> str:
+        """Truncated title for display."""
+        return obj.title[:60] + "..." if len(obj.title) > 60 else obj.title
+    title_preview.short_description = "Title"
+
+    def status_badge(self, obj: IndexedDocument) -> str:
+        """Colored status badge."""
+        colors = {
+            DocumentStatus.PENDING: "gray",
+            DocumentStatus.PROCESSING: "blue",
+            DocumentStatus.READY: "green",
+            DocumentStatus.FAILED: "red",
+        }
+        color = colors.get(obj.status, "gray")
+        return format_html(
+            '<span style="color: {}; font-weight: bold;">{}</span>',
+            color,
+            obj.get_status_display(),
+        )
+    status_badge.short_description = "Status"
+
+    def chunk_count(self, obj: IndexedDocument) -> int:
+        """Number of chunks for this document."""
+        return obj.chunks.count()
+    chunk_count.short_description = "Chunks"
+
+    def reindex_selected(self, request, queryset):
+        """Reindex selected documents."""
+        count = 0
+        for doc in queryset:
+            if doc.source_type == "scientific_doc":
+                index_scientific_document_task.delay(str(doc.id))
+                count += 1
+        self.message_user(
+            request,
+            f"Queued {count} documents for reindexing.",
+        )
+    reindex_selected.short_description = "Reindex selected documents"
+
+    def mark_as_pending(self, request, queryset):
+        """Mark selected documents as pending."""
+        count = queryset.update(status=DocumentStatus.PENDING)
+        self.message_user(request, f"Marked {count} documents as pending.")
+    mark_as_pending.short_description = "Mark as pending"
+
+
+@admin.register(DocumentChunk)
+class DocumentChunkAdmin(admin.ModelAdmin):
+    """Admin for DocumentChunk model."""
+
+    list_display = [
+        "id",
+        "document_title",
+        "chunk_index",
+        "section",
+        "content_preview",
+        "has_embedding",
+        "created_at",
+    ]
+    list_filter = ["embedding_model", "document__source_type"]
+    search_fields = ["content", "document__title"]
+    readonly_fields = ["id", "created_at"]
+    raw_id_fields = ["document"]
+    ordering = ["document", "chunk_index"]
+
+    def document_title(self, obj: DocumentChunk) -> str:
+        """Document title."""
+        return obj.document.title[:40] + "..." if len(obj.document.title) > 40 else obj.document.title
+    document_title.short_description = "Document"
+
+    def content_preview(self, obj: DocumentChunk) -> str:
+        """Truncated content for display."""
+        return obj.content[:80] + "..." if len(obj.content) > 80 else obj.content
+    content_preview.short_description = "Content"
+
+    def has_embedding(self, obj: DocumentChunk) -> bool:
+        """Whether chunk has an embedding."""
+        return obj.embedding is not None
+    has_embedding.boolean = True
+    has_embedding.short_description = "Embedded"

--- a/backend/apps/rag/apps.py
+++ b/backend/apps/rag/apps.py
@@ -1,0 +1,11 @@
+"""RAG app configuration."""
+
+from django.apps import AppConfig
+
+
+class RagConfig(AppConfig):
+    """RAG application configuration."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.rag"
+    verbose_name = "RAG Knowledge Base"

--- a/backend/apps/rag/management/__init__.py
+++ b/backend/apps/rag/management/__init__.py
@@ -1,0 +1,1 @@
+"""RAG management commands."""

--- a/backend/apps/rag/management/commands/__init__.py
+++ b/backend/apps/rag/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""RAG management commands."""

--- a/backend/apps/rag/management/commands/backfill_rag_index.py
+++ b/backend/apps/rag/management/commands/backfill_rag_index.py
@@ -1,0 +1,147 @@
+"""Management command to backfill RAG index with existing data."""
+
+from django.core.management.base import BaseCommand, CommandParser
+from django.contrib.auth import get_user_model
+
+from apps.rag.tasks import (
+    index_simulation_task,
+    index_analysis_task,
+    reindex_all_user_data,
+)
+
+
+class Command(BaseCommand):
+    """Backfill RAG index with existing simulations and analyses."""
+
+    help = "Backfill RAG index with existing simulations and analyses"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="Index only for specific user email",
+        )
+        parser.add_argument(
+            "--sync",
+            action="store_true",
+            help="Run synchronously instead of queuing tasks",
+        )
+        parser.add_argument(
+            "--simulations-only",
+            action="store_true",
+            help="Only index simulations",
+        )
+        parser.add_argument(
+            "--analyses-only",
+            action="store_true",
+            help="Only index analyses",
+        )
+
+    def handle(self, *args, **options) -> None:
+        User = get_user_model()
+
+        if options["user"]:
+            try:
+                users = [User.objects.get(email=options["user"])]
+            except User.DoesNotExist:
+                self.stderr.write(
+                    self.style.ERROR(f"User not found: {options['user']}")
+                )
+                return
+        else:
+            users = User.objects.all()
+
+        total_queued = 0
+
+        for user in users:
+            self.stdout.write(f"Processing user: {user.email}")
+
+            if options["sync"]:
+                # Run synchronously
+                queued = self._index_sync(
+                    user,
+                    simulations_only=options["simulations_only"],
+                    analyses_only=options["analyses_only"],
+                )
+            else:
+                # Queue for async processing
+                if not options["simulations_only"] and not options["analyses_only"]:
+                    # Use the combined task
+                    reindex_all_user_data.delay(str(user.id))
+                    queued = "all (async)"
+                else:
+                    queued = self._queue_tasks(
+                        user,
+                        simulations_only=options["simulations_only"],
+                        analyses_only=options["analyses_only"],
+                    )
+
+            self.stdout.write(f"  Queued: {queued}")
+            if isinstance(queued, int):
+                total_queued += queued
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Backfill initiated. Total queued: {total_queued}")
+        )
+
+    def _index_sync(self, user, simulations_only: bool, analyses_only: bool) -> int:
+        """Index synchronously for a user."""
+        from apps.simulations.models import Simulation, SimulationStatus
+        from apps.fractal_analysis.models import FraktalAnalysis, AnalysisStatus
+
+        count = 0
+
+        if not analyses_only:
+            sims = Simulation.objects.filter(
+                project__owner=user,
+                status=SimulationStatus.COMPLETED,
+            )
+            for sim in sims:
+                result = index_simulation_task(str(sim.id))
+                status = result.get("status", "unknown")
+                self.stdout.write(f"    Simulation {sim.id}: {status}")
+                if status == "success":
+                    count += 1
+
+        if not simulations_only:
+            analyses = FraktalAnalysis.objects.filter(
+                project__owner=user,
+                status=AnalysisStatus.COMPLETED,
+            )
+            for analysis in analyses:
+                result = index_analysis_task(str(analysis.id))
+                status = result.get("status", "unknown")
+                self.stdout.write(f"    Analysis {analysis.id}: {status}")
+                if status == "success":
+                    count += 1
+
+        return count
+
+    def _queue_tasks(
+        self, user, simulations_only: bool, analyses_only: bool
+    ) -> int:
+        """Queue indexing tasks for a user."""
+        from apps.simulations.models import Simulation, SimulationStatus
+        from apps.fractal_analysis.models import FraktalAnalysis, AnalysisStatus
+
+        count = 0
+
+        if not analyses_only:
+            sims = Simulation.objects.filter(
+                project__owner=user,
+                status=SimulationStatus.COMPLETED,
+            ).values_list("id", flat=True)
+            for sim_id in sims:
+                index_simulation_task.delay(str(sim_id))
+                count += 1
+
+        if not simulations_only:
+            analyses = FraktalAnalysis.objects.filter(
+                project__owner=user,
+                status=AnalysisStatus.COMPLETED,
+            ).values_list("id", flat=True)
+            for analysis_id in analyses:
+                index_analysis_task.delay(str(analysis_id))
+                count += 1
+
+        return count

--- a/backend/apps/rag/management/commands/seed_scientific_docs.py
+++ b/backend/apps/rag/management/commands/seed_scientific_docs.py
@@ -1,0 +1,296 @@
+"""Management command to seed scientific documentation for RAG."""
+
+from django.core.management.base import BaseCommand
+
+from apps.rag.models import IndexedDocument, DocumentSource, DocumentStatus
+from apps.rag.tasks import index_scientific_document_task
+
+
+# Foundational scientific documentation about DLA, CCA, and fractal analysis
+SEED_DOCUMENTS = [
+    {
+        "title": "Diffusion-Limited Aggregation (DLA) Overview",
+        "abstract": """
+Diffusion-Limited Aggregation (DLA) is a process where particles undergo random walks
+and stick irreversibly upon first contact with a growing cluster. The resulting
+aggregates have a characteristic fractal dimension.
+
+Key characteristics:
+- Fractal dimension Df approximately 1.71 in 2D and 2.5 in 3D
+- Prefactor kf typically around 1.3
+- Open, branching structure with dendritic morphology
+- Self-similar at different scales
+- Introduced by Witten and Sander in 1981
+
+The DLA model is widely used in:
+- Electrodeposition modeling
+- Crystal growth simulation
+- Aerosol particle aggregation
+- Biological pattern formation
+
+The fractal dimension of DLA clusters depends on the dimensionality of space:
+- 2D: Df ≈ 1.71
+- 3D: Df ≈ 2.50
+
+The scaling relationship is: N = kf * (Rg/a)^Df
+where N is the number of particles, Rg is the radius of gyration, and a is the
+primary particle radius.
+""",
+        "authors": ["System Documentation"],
+        "year": 2024,
+    },
+    {
+        "title": "Cluster-Cluster Aggregation (CCA/DLCA) Overview",
+        "abstract": """
+Cluster-Cluster Aggregation (CCA), also known as Diffusion-Limited Cluster Aggregation
+(DLCA), is a process where clusters of particles diffuse and aggregate with other
+clusters upon contact.
+
+Key characteristics:
+- Fractal dimension Df approximately 1.78 in 2D and 1.8 in 3D
+- More compact structure than DLA
+- Clusters grow by merging with other clusters, not just single particles
+- Results in more uniform, less dendritic structures
+
+Comparison with DLA:
+- CCA produces lower fractal dimensions than DLA
+- CCA clusters are more compact and less branched
+- CCA better represents real aerosol aggregation processes
+
+The CCA model is particularly relevant for:
+- Soot particle formation
+- Colloidal aggregation
+- Aerosol science
+- Nanoparticle synthesis
+
+Typical fractal dimensions for CCA:
+- 3D DLCA: Df ≈ 1.78-1.82
+- 3D RLCA (Reaction-Limited): Df ≈ 2.0-2.1
+""",
+        "authors": ["System Documentation"],
+        "year": 2024,
+    },
+    {
+        "title": "Ballistic Aggregation Overview",
+        "abstract": """
+Ballistic Aggregation is a process where particles travel in straight lines and
+stick upon contact with the cluster. This contrasts with diffusion-based processes
+where particles follow random walks.
+
+Key types:
+1. Ballistic Particle-Cluster Aggregation (BPCA):
+   - Single particles attach to a growing cluster
+   - Fractal dimension Df ≈ 3.0 (nearly space-filling)
+   - Very compact structures
+
+2. Ballistic Cluster-Cluster Aggregation (BCCA):
+   - Clusters collide ballistically
+   - Fractal dimension Df ≈ 1.95
+   - More compact than DLCA
+
+Characteristics:
+- Produces more compact aggregates than diffusion-limited processes
+- Relevant for high-velocity particle collisions
+- Important in astrophysical dust aggregation
+- Used in modeling dense aerosol systems
+
+The ballistic limit represents one extreme of aggregation dynamics, with the
+diffusion limit at the other extreme. Real systems often fall between these limits.
+""",
+        "authors": ["System Documentation"],
+        "year": 2024,
+    },
+    {
+        "title": "Fractal Dimension Measurement Methods",
+        "abstract": """
+Fractal dimension (Df) can be measured using several methods:
+
+1. Box-Counting Method:
+   - Covers the aggregate with boxes of size ε
+   - Counts boxes N(ε) containing part of the aggregate
+   - Df = -d(log N) / d(log ε)
+   - Most common method for discrete particle aggregates
+
+2. Sandbox Method:
+   - Counts particles within radius r from center of mass
+   - N(r) ~ r^Df
+   - Good for 3D aggregates
+
+3. Correlation Dimension:
+   - Uses pair correlation function
+   - Df from slope of log-log plot
+
+4. Radius of Gyration Method:
+   - Uses scaling: N = kf * (Rg/a)^Df
+   - Requires known prefactor kf
+   - Common in aerosol science
+
+Typical values:
+- DLA 3D: Df ≈ 2.5
+- DLCA 3D: Df ≈ 1.78
+- BCCA: Df ≈ 1.95
+- BPCA: Df ≈ 3.0
+
+The prefactor kf depends on the aggregation mechanism:
+- DLCA: kf ≈ 1.3
+- BCCA: kf ≈ 1.4
+- Higher kf indicates more compact packing at small scales
+""",
+        "authors": ["System Documentation"],
+        "year": 2024,
+    },
+    {
+        "title": "Sticking Probability Effects on Aggregation",
+        "abstract": """
+Sticking probability (Ps) determines the likelihood that particles stick upon contact.
+This parameter allows transition between different aggregation regimes.
+
+Effects of sticking probability:
+- Ps = 1 (DLCA): Irreversible sticking, lower Df
+- Ps << 1 (RLCA): Reaction-limited, particles may bounce before sticking
+- Lower Ps leads to more compact aggregates and higher Df
+
+Reaction-Limited Cluster Aggregation (RLCA):
+- Sticking probability significantly less than 1
+- Particles can penetrate deeper into clusters before sticking
+- Results in more compact structures
+- Df ≈ 2.0-2.1 in 3D
+
+The transition from DLCA to RLCA:
+- As Ps decreases, Df increases
+- The prefactor kf also increases
+- Aggregate morphology becomes more compact
+
+Applications:
+- Ps < 1 simulates:
+  - Electrostatic repulsion between particles
+  - Energy barriers to aggregation
+  - Partially reversible aggregation
+  - Polymer-mediated interactions
+""",
+        "authors": ["System Documentation"],
+        "year": 2024,
+    },
+    {
+        "title": "Sintering in Particle Aggregates",
+        "abstract": """
+Sintering is the process where contact between particles grows over time,
+leading to particle fusion and restructuring of aggregates.
+
+Effects on aggregate structure:
+- Increases overlap between particles
+- Reduces porosity
+- Can increase fractal dimension as structure compacts
+- Changes optical and mechanical properties
+
+Sintering coefficient:
+- Represents the degree of particle overlap
+- Value of 0: Point contact (no sintering)
+- Value > 0: Particles overlap/fuse
+- Typical range: 0 to 0.5
+
+Impact on measurements:
+- Affects radius of gyration calculation
+- Changes effective fractal dimension
+- Modifies prefactor kf
+- Important for accurate modeling of real aerosols
+
+Sintering is particularly important in:
+- Soot particle modeling
+- Flame-generated nanoparticles
+- High-temperature aerosols
+- Metal particle synthesis
+""",
+        "authors": ["System Documentation"],
+        "year": 2024,
+    },
+]
+
+
+class Command(BaseCommand):
+    """Seed the RAG database with scientific documentation."""
+
+    help = "Seed the RAG database with foundational scientific documentation"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Overwrite existing documents with the same title",
+        )
+        parser.add_argument(
+            "--sync",
+            action="store_true",
+            help="Index synchronously instead of queuing tasks",
+        )
+
+    def handle(self, *args, **options):
+        created_count = 0
+        updated_count = 0
+        skipped_count = 0
+
+        for doc_data in SEED_DOCUMENTS:
+            existing = IndexedDocument.objects.filter(
+                title=doc_data["title"],
+                source_type=DocumentSource.SCIENTIFIC_DOC,
+                is_global=True,
+            ).first()
+
+            if existing:
+                if options["force"]:
+                    # Update existing document
+                    existing.abstract = doc_data["abstract"]
+                    existing.authors = doc_data["authors"]
+                    existing.year = doc_data["year"]
+                    existing.status = DocumentStatus.PENDING
+                    existing.save()
+                    updated_count += 1
+
+                    if options["sync"]:
+                        result = index_scientific_document_task(str(existing.id))
+                        self.stdout.write(
+                            f"  Updated and indexed: {doc_data['title'][:50]}... "
+                            f"({result.get('status', 'unknown')})"
+                        )
+                    else:
+                        index_scientific_document_task.delay(str(existing.id))
+                        self.stdout.write(
+                            f"  Updated and queued: {doc_data['title'][:50]}..."
+                        )
+                else:
+                    skipped_count += 1
+                    self.stdout.write(
+                        f"  Skipped (exists): {doc_data['title'][:50]}..."
+                    )
+            else:
+                # Create new document
+                doc = IndexedDocument.objects.create(
+                    title=doc_data["title"],
+                    abstract=doc_data["abstract"],
+                    authors=doc_data["authors"],
+                    year=doc_data["year"],
+                    source_type=DocumentSource.SCIENTIFIC_DOC,
+                    is_global=True,
+                    status=DocumentStatus.PENDING,
+                    content_hash="",
+                )
+                created_count += 1
+
+                if options["sync"]:
+                    result = index_scientific_document_task(str(doc.id))
+                    self.stdout.write(
+                        f"  Created and indexed: {doc_data['title'][:50]}... "
+                        f"({result.get('status', 'unknown')})"
+                    )
+                else:
+                    index_scientific_document_task.delay(str(doc.id))
+                    self.stdout.write(
+                        f"  Created and queued: {doc_data['title'][:50]}..."
+                    )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Seeding complete: {created_count} created, "
+                f"{updated_count} updated, {skipped_count} skipped"
+            )
+        )

--- a/backend/apps/rag/migrations/0001_initial.py
+++ b/backend/apps/rag/migrations/0001_initial.py
@@ -1,0 +1,224 @@
+"""Initial migration for RAG app with pgvector support."""
+
+import uuid
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import pgvector.django
+
+
+class Migration(migrations.Migration):
+    """Create RAG models with pgvector extension."""
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        # Enable pgvector extension
+        migrations.RunSQL(
+            "CREATE EXTENSION IF NOT EXISTS vector;",
+            reverse_sql="DROP EXTENSION IF EXISTS vector;",
+        ),
+        # Create IndexedDocument model
+        migrations.CreateModel(
+            name="IndexedDocument",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "source_type",
+                    models.CharField(
+                        choices=[
+                            ("simulation", "Simulation Results"),
+                            ("analysis", "Analysis Results"),
+                            ("study", "Parametric Study"),
+                            ("scientific_doc", "Scientific Documentation"),
+                            ("uploaded", "Uploaded Document"),
+                        ],
+                        db_index=True,
+                        max_length=30,
+                    ),
+                ),
+                (
+                    "source_id",
+                    models.UUIDField(
+                        blank=True,
+                        db_index=True,
+                        help_text="ID of source object (simulation, analysis, etc.)",
+                        null=True,
+                    ),
+                ),
+                ("title", models.CharField(max_length=500)),
+                (
+                    "content_hash",
+                    models.CharField(
+                        db_index=True,
+                        help_text="SHA-256 hash to detect content changes",
+                        max_length=64,
+                    ),
+                ),
+                ("authors", models.JSONField(blank=True, default=list)),
+                ("year", models.IntegerField(blank=True, null=True)),
+                ("abstract", models.TextField(blank=True)),
+                ("url", models.URLField(blank=True)),
+                (
+                    "file",
+                    models.FileField(
+                        blank=True, null=True, upload_to="rag_documents/"
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("processing", "Processing"),
+                            ("ready", "Ready"),
+                            ("failed", "Failed"),
+                        ],
+                        db_index=True,
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("error_message", models.TextField(blank=True)),
+                (
+                    "metadata",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        help_text="Additional metadata (algorithm, parameters, metrics, etc.)",
+                    ),
+                ),
+                (
+                    "is_global",
+                    models.BooleanField(
+                        db_index=True,
+                        default=False,
+                        help_text="Global documents (scientific literature) visible to all users",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("indexed_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Owner for user-specific documents (simulations, analyses)",
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="indexed_documents",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Indexed Document",
+                "verbose_name_plural": "Indexed Documents",
+                "db_table": "rag_indexed_documents",
+                "ordering": ["-created_at"],
+            },
+        ),
+        # Create DocumentChunk model
+        migrations.CreateModel(
+            name="DocumentChunk",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("content", models.TextField()),
+                (
+                    "chunk_index",
+                    models.IntegerField(
+                        help_text="Order of this chunk within the document"
+                    ),
+                ),
+                (
+                    "embedding",
+                    pgvector.django.VectorField(
+                        blank=True, dimensions=1536, null=True
+                    ),
+                ),
+                (
+                    "embedding_model",
+                    models.CharField(
+                        default="text-embedding-3-small", max_length=100
+                    ),
+                ),
+                (
+                    "section",
+                    models.CharField(
+                        blank=True,
+                        help_text="Section heading if applicable",
+                        max_length=200,
+                    ),
+                ),
+                ("page_number", models.IntegerField(blank=True, null=True)),
+                ("metadata", models.JSONField(blank=True, default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "document",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="chunks",
+                        to="rag.indexeddocument",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Document Chunk",
+                "verbose_name_plural": "Document Chunks",
+                "db_table": "rag_document_chunks",
+                "ordering": ["document", "chunk_index"],
+            },
+        ),
+        # Add indexes for IndexedDocument
+        migrations.AddIndex(
+            model_name="indexeddocument",
+            index=models.Index(
+                fields=["source_type", "source_id"],
+                name="rag_indexed_source_type_e98a75_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="indexeddocument",
+            index=models.Index(
+                fields=["owner", "source_type"],
+                name="rag_indexed_owner_i_0c6e7a_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="indexeddocument",
+            index=models.Index(
+                fields=["is_global", "status"],
+                name="rag_indexed_is_glob_8d3d0a_idx",
+            ),
+        ),
+        # Create HNSW index for vector similarity search
+        migrations.RunSQL(
+            """
+            CREATE INDEX IF NOT EXISTS rag_chunk_embedding_hnsw_idx
+            ON rag_document_chunks
+            USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64);
+            """,
+            reverse_sql="DROP INDEX IF EXISTS rag_chunk_embedding_hnsw_idx;",
+        ),
+    ]

--- a/backend/apps/rag/migrations/__init__.py
+++ b/backend/apps/rag/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""RAG migrations."""

--- a/backend/apps/rag/models.py
+++ b/backend/apps/rag/models.py
@@ -1,0 +1,213 @@
+"""RAG models for document indexing and retrieval."""
+
+import uuid
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+from django.db import models
+from pgvector.django import VectorField
+
+if TYPE_CHECKING:
+    from apps.simulations.models import Simulation
+    from apps.fractal_analysis.models import FraktalAnalysis
+
+
+class DocumentSource(models.TextChoices):
+    """Source type of the indexed document."""
+
+    SIMULATION = "simulation", "Simulation Results"
+    ANALYSIS = "analysis", "Analysis Results"
+    STUDY = "study", "Parametric Study"
+    SCIENTIFIC_DOC = "scientific_doc", "Scientific Documentation"
+    UPLOADED = "uploaded", "Uploaded Document"
+
+
+class DocumentStatus(models.TextChoices):
+    """Document processing status."""
+
+    PENDING = "pending", "Pending"
+    PROCESSING = "processing", "Processing"
+    READY = "ready", "Ready"
+    FAILED = "failed", "Failed"
+
+
+class IndexedDocument(models.Model):
+    """Represents a document in the RAG knowledge base.
+
+    Each document can be:
+    - A user's simulation (auto-indexed on completion)
+    - A user's analysis (auto-indexed on completion)
+    - Scientific literature (global, admin-uploaded)
+    - User-uploaded documentation
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # Source tracking
+    source_type = models.CharField(
+        max_length=30,
+        choices=DocumentSource.choices,
+        db_index=True,
+    )
+    source_id = models.UUIDField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="ID of source object (simulation, analysis, etc.)",
+    )
+
+    # Document metadata
+    title = models.CharField(max_length=500)
+    content_hash = models.CharField(
+        max_length=64,
+        db_index=True,
+        help_text="SHA-256 hash to detect content changes",
+    )
+
+    # For scientific docs
+    authors = models.JSONField(default=list, blank=True)
+    year = models.IntegerField(null=True, blank=True)
+    abstract = models.TextField(blank=True)
+    url = models.URLField(blank=True)
+    file = models.FileField(upload_to="rag_documents/", null=True, blank=True)
+
+    # Processing status
+    status = models.CharField(
+        max_length=20,
+        choices=DocumentStatus.choices,
+        default=DocumentStatus.PENDING,
+        db_index=True,
+    )
+    error_message = models.TextField(blank=True)
+
+    # Structured metadata for filtering
+    metadata = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Additional metadata (algorithm, parameters, metrics, etc.)",
+    )
+
+    # Ownership (for user data isolation)
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="indexed_documents",
+        help_text="Owner for user-specific documents (simulations, analyses)",
+    )
+    is_global = models.BooleanField(
+        default=False,
+        db_index=True,
+        help_text="Global documents (scientific literature) visible to all users",
+    )
+
+    # Timestamps
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    indexed_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "rag_indexed_documents"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["source_type", "source_id"]),
+            models.Index(fields=["owner", "source_type"]),
+            models.Index(fields=["is_global", "status"]),
+        ]
+        verbose_name = "Indexed Document"
+        verbose_name_plural = "Indexed Documents"
+
+    def __str__(self) -> str:
+        return f"{self.get_source_type_display()}: {self.title}"
+
+    @classmethod
+    def get_or_create_for_simulation(
+        cls, simulation: "Simulation"
+    ) -> tuple["IndexedDocument", bool]:
+        """Get or create an IndexedDocument for a simulation."""
+        return cls.objects.get_or_create(
+            source_type=DocumentSource.SIMULATION,
+            source_id=simulation.id,
+            defaults={
+                "title": cls._build_simulation_title(simulation),
+                "owner": simulation.project.owner,
+                "is_global": False,
+                "content_hash": "",
+            },
+        )
+
+    @classmethod
+    def get_or_create_for_analysis(
+        cls, analysis: "FraktalAnalysis"
+    ) -> tuple["IndexedDocument", bool]:
+        """Get or create an IndexedDocument for a FRAKTAL analysis."""
+        return cls.objects.get_or_create(
+            source_type=DocumentSource.ANALYSIS,
+            source_id=analysis.id,
+            defaults={
+                "title": cls._build_analysis_title(analysis),
+                "owner": analysis.project.owner,
+                "is_global": False,
+                "content_hash": "",
+            },
+        )
+
+    @staticmethod
+    def _build_simulation_title(simulation: "Simulation") -> str:
+        """Generate a descriptive title for a simulation."""
+        n_particles = simulation.parameters.get("n_particles", "?")
+        return f"{simulation.algorithm.upper()} simulation with {n_particles} particles"
+
+    @staticmethod
+    def _build_analysis_title(analysis: "FraktalAnalysis") -> str:
+        """Generate a descriptive title for an analysis."""
+        return f"FRAKTAL {analysis.model.upper()} analysis"
+
+
+class DocumentChunk(models.Model):
+    """A chunk of text from a document with its embedding vector.
+
+    Chunks are created during indexing and stored with their embeddings
+    for efficient semantic search using pgvector.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    document = models.ForeignKey(
+        IndexedDocument,
+        on_delete=models.CASCADE,
+        related_name="chunks",
+    )
+
+    # Chunk content
+    content = models.TextField()
+    chunk_index = models.IntegerField(
+        help_text="Order of this chunk within the document"
+    )
+
+    # Embedding vector (1536 dimensions for text-embedding-3-small)
+    embedding = VectorField(dimensions=1536, null=True, blank=True)
+    embedding_model = models.CharField(
+        max_length=100, default="text-embedding-3-small"
+    )
+
+    # Chunk metadata
+    section = models.CharField(
+        max_length=200,
+        blank=True,
+        help_text="Section heading if applicable",
+    )
+    page_number = models.IntegerField(null=True, blank=True)
+    metadata = models.JSONField(default=dict, blank=True)
+
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "rag_document_chunks"
+        ordering = ["document", "chunk_index"]
+        verbose_name = "Document Chunk"
+        verbose_name_plural = "Document Chunks"
+
+    def __str__(self) -> str:
+        preview = self.content[:50] + "..." if len(self.content) > 50 else self.content
+        return f"Chunk {self.chunk_index}: {preview}"

--- a/backend/apps/rag/services/__init__.py
+++ b/backend/apps/rag/services/__init__.py
@@ -1,0 +1,16 @@
+"""RAG services."""
+
+from .embedding_service import EmbeddingService, get_embedding_service
+from .search_service import RAGSearchService, SearchResult, get_search_service
+from .chunking import chunk_simulation_data, chunk_analysis_data, chunk_scientific_document
+
+__all__ = [
+    "EmbeddingService",
+    "get_embedding_service",
+    "RAGSearchService",
+    "SearchResult",
+    "get_search_service",
+    "chunk_simulation_data",
+    "chunk_analysis_data",
+    "chunk_scientific_document",
+]

--- a/backend/apps/rag/services/chunking.py
+++ b/backend/apps/rag/services/chunking.py
@@ -1,0 +1,243 @@
+"""Document chunking strategies for RAG indexing."""
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from apps.simulations.models import Simulation
+    from apps.fractal_analysis.models import FraktalAnalysis
+    from apps.rag.models import IndexedDocument
+
+
+def chunk_simulation_data(
+    content: str, simulation: "Simulation"
+) -> list[dict[str, Any]]:
+    """Chunk simulation data with domain-specific strategy.
+
+    For simulations, we create semantic chunks:
+    1. Overview chunk (algorithm, parameters)
+    2. Results chunk (metrics)
+
+    Args:
+        content: Full text content of the simulation.
+        simulation: The Simulation object.
+
+    Returns:
+        List of chunk dictionaries with content, section, and metadata.
+    """
+    chunks = []
+
+    # Overview chunk
+    overview = _build_simulation_overview(simulation)
+    chunks.append({
+        "content": overview,
+        "section": "overview",
+        "metadata": {"chunk_type": "overview"},
+    })
+
+    # Results chunk (if metrics exist)
+    if simulation.metrics:
+        results = _build_simulation_results(simulation.metrics)
+        chunks.append({
+            "content": results,
+            "section": "results",
+            "metadata": {"chunk_type": "results"},
+        })
+
+    return chunks
+
+
+def chunk_analysis_data(
+    content: str, analysis: "FraktalAnalysis"
+) -> list[dict[str, Any]]:
+    """Chunk FRAKTAL analysis data.
+
+    Args:
+        content: Full text content of the analysis.
+        analysis: The FraktalAnalysis object.
+
+    Returns:
+        List of chunk dictionaries.
+    """
+    chunks = []
+
+    # Overview chunk
+    overview = _build_analysis_overview(analysis)
+    chunks.append({
+        "content": overview,
+        "section": "overview",
+        "metadata": {"chunk_type": "overview"},
+    })
+
+    # Results chunk (if results exist)
+    if analysis.results:
+        results = _build_analysis_results(analysis.results)
+        chunks.append({
+            "content": results,
+            "section": "results",
+            "metadata": {"chunk_type": "results"},
+        })
+
+    return chunks
+
+
+def chunk_scientific_document(
+    content: str, document: "IndexedDocument"
+) -> list[dict[str, Any]]:
+    """Chunk scientific document with overlap for context preservation.
+
+    Uses sentence-aware chunking with ~500 token chunks and 50 token overlap.
+
+    Args:
+        content: Full text content of the document.
+        document: The IndexedDocument object.
+
+    Returns:
+        List of chunk dictionaries.
+    """
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=2000,  # ~500 tokens
+        chunk_overlap=200,  # ~50 tokens
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+
+    texts = splitter.split_text(content)
+
+    chunks = []
+    for i, text in enumerate(texts):
+        chunks.append({
+            "content": text,
+            "section": "",
+            "metadata": {"chunk_type": "scientific"},
+        })
+
+    return chunks
+
+
+def _build_simulation_overview(simulation: "Simulation") -> str:
+    """Build overview chunk for simulation."""
+    parts = [
+        "Simulation Overview:",
+        f"Algorithm: {simulation.algorithm.upper()} ({simulation.get_algorithm_display()})",
+        f"Particles: {simulation.parameters.get('n_particles', 'N/A')}",
+        f"Seed: {simulation.seed}",
+        "",
+        "Parameters:",
+    ]
+
+    # Add all parameters
+    param_descriptions = {
+        "n_particles": "Number of particles",
+        "sticking_probability": "Sticking probability",
+        "particle_radius": "Particle radius",
+        "max_attempts": "Maximum walk attempts",
+        "grid_size": "Grid size",
+        "fractal_dimension": "Target fractal dimension",
+        "prefactor": "Target prefactor",
+        "n_primary": "Primary particles per cluster",
+        "sigma": "Size distribution sigma",
+        "sintering_coefficient": "Sintering coefficient",
+    }
+
+    for key, value in simulation.parameters.items():
+        desc = param_descriptions.get(key, key.replace("_", " ").title())
+        parts.append(f"  - {desc}: {value}")
+
+    return "\n".join(parts)
+
+
+def _build_simulation_results(metrics: dict[str, Any]) -> str:
+    """Build results chunk from simulation metrics."""
+    parts = ["Simulation Results:"]
+
+    # Key metrics with descriptions
+    metric_info = [
+        ("fractal_dimension", "Fractal Dimension (Df)", ".4f"),
+        ("fractal_dimension_std", "  Standard Deviation", ".4f"),
+        ("prefactor", "Prefactor (kf)", ".4f"),
+        ("radius_of_gyration", "Radius of Gyration (Rg)", ".4f"),
+        ("porosity", "Porosity", ".4f"),
+        ("overlap_volume", "Overlap Volume", ".4f"),
+    ]
+
+    for key, label, fmt in metric_info:
+        if key in metrics:
+            value = metrics[key]
+            if isinstance(value, float):
+                parts.append(f"  - {label}: {value:{fmt}}")
+            else:
+                parts.append(f"  - {label}: {value}")
+
+    # Coordination number (nested dict)
+    if "coordination" in metrics:
+        coord = metrics["coordination"]
+        if isinstance(coord, dict):
+            mean = coord.get("mean", "N/A")
+            std = coord.get("std", "N/A")
+            if isinstance(mean, float):
+                parts.append(f"  - Coordination Number: {mean:.2f} (std: {std:.2f})")
+            else:
+                parts.append(f"  - Coordination Number: {mean}")
+
+    return "\n".join(parts)
+
+
+def _build_analysis_overview(analysis: "FraktalAnalysis") -> str:
+    """Build overview chunk for FRAKTAL analysis."""
+    parts = [
+        "FRAKTAL Analysis Overview:",
+        f"Model: {analysis.model.upper()} ({analysis.get_model_display()})",
+        f"Source: {analysis.get_source_type_display()}",
+        "",
+        "Analysis Parameters:",
+    ]
+
+    # Key parameters
+    param_info = [
+        ("npix", "Image resolution (npix)"),
+        ("dpo", "Primary particle diameter (dpo)"),
+        ("delta", "Pixel size (delta)"),
+        ("correction_3d", "3D correction"),
+        ("pixel_min", "Minimum pixel count"),
+        ("pixel_max", "Maximum pixel count"),
+        ("npo_limit", "NPO limit"),
+        ("escala", "Scale factor"),
+        ("auto_calibrate", "Auto-calibrated"),
+    ]
+
+    for key, label in param_info:
+        value = getattr(analysis, key, None)
+        if value is not None:
+            parts.append(f"  - {label}: {value}")
+
+    return "\n".join(parts)
+
+
+def _build_analysis_results(results: dict[str, Any]) -> str:
+    """Build results chunk from FRAKTAL analysis results."""
+    parts = ["FRAKTAL Analysis Results:"]
+
+    # Key results with descriptions
+    result_info = [
+        ("df", "Fractal Dimension (Df)", ".4f"),
+        ("rg", "Radius of Gyration (Rg)", ".4f"),
+        ("ap", "Primary Particle Area (Ap)", ".4f"),
+        ("npo", "Number of Primary Particles (Npo)", ".1f"),
+        ("kf", "Prefactor (kf)", ".4f"),
+        ("zf", "Zf coefficient", ".4f"),
+        ("jf", "Jf coefficient", ".4f"),
+        ("volume", "Volume", ".4f"),
+        ("mass", "Mass", ".4f"),
+        ("surface_area", "Surface Area", ".4f"),
+    ]
+
+    for key, label, fmt in result_info:
+        if key in results:
+            value = results[key]
+            if isinstance(value, float):
+                parts.append(f"  - {label}: {value:{fmt}}")
+            else:
+                parts.append(f"  - {label}: {value}")
+
+    return "\n".join(parts)

--- a/backend/apps/rag/services/embedding_service.py
+++ b/backend/apps/rag/services/embedding_service.py
@@ -1,0 +1,183 @@
+"""Embedding service for RAG using OpenAI text-embedding-3-small."""
+
+import logging
+from functools import lru_cache
+from typing import Protocol
+
+from django.conf import settings
+import openai
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingProvider(Protocol):
+    """Protocol for embedding providers."""
+
+    def embed_text(self, text: str) -> list[float]:
+        """Generate embedding for a single text."""
+        ...
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for multiple texts."""
+        ...
+
+    @property
+    def dimensions(self) -> int:
+        """Return embedding dimensions."""
+        ...
+
+    @property
+    def model_name(self) -> str:
+        """Return model identifier."""
+        ...
+
+
+class OpenAIEmbeddingProvider:
+    """OpenAI embedding provider using text-embedding-3-small.
+
+    This model provides 1536-dimensional embeddings at low cost
+    ($0.02 per 1M tokens) with excellent quality for semantic search.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "text-embedding-3-small",
+    ):
+        self._model = model
+        self._client = openai.OpenAI(
+            api_key=api_key or getattr(settings, "OPENAI_API_KEY", None)
+        )
+        self._dimensions = 1536  # text-embedding-3-small dimensions
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    def embed_text(self, text: str) -> list[float]:
+        """Generate embedding for a single text.
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            List of floats representing the embedding vector.
+        """
+        response = self._client.embeddings.create(
+            model=self._model,
+            input=text,
+        )
+        return response.data[0].embedding
+
+    def embed_batch(
+        self, texts: list[str], batch_size: int = 100
+    ) -> list[list[float]]:
+        """Generate embeddings for multiple texts in batches.
+
+        Args:
+            texts: List of texts to embed.
+            batch_size: Maximum texts per API call (default 100).
+
+        Returns:
+            List of embedding vectors in the same order as input.
+        """
+        if not texts:
+            return []
+
+        all_embeddings: list[list[float]] = []
+
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i : i + batch_size]
+            response = self._client.embeddings.create(
+                model=self._model,
+                input=batch,
+            )
+            # Sort by index to maintain order
+            sorted_data = sorted(response.data, key=lambda x: x.index)
+            all_embeddings.extend([d.embedding for d in sorted_data])
+
+        return all_embeddings
+
+
+class EmbeddingService:
+    """Main embedding service with preprocessing and provider abstraction.
+
+    Usage:
+        service = get_embedding_service()
+        embedding = service.embed_text("Some text to embed")
+        embeddings = service.embed_batch(["Text 1", "Text 2"])
+    """
+
+    def __init__(self, provider: EmbeddingProvider | None = None):
+        self._provider = provider or self._get_default_provider()
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _get_default_provider() -> EmbeddingProvider:
+        """Get cached default provider."""
+        return OpenAIEmbeddingProvider()
+
+    def embed_text(self, text: str) -> list[float]:
+        """Generate embedding for text with preprocessing.
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            Embedding vector as list of floats.
+        """
+        processed = self._preprocess(text)
+        return self._provider.embed_text(processed)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for batch of texts.
+
+        Args:
+            texts: List of texts to embed.
+
+        Returns:
+            List of embedding vectors.
+        """
+        processed = [self._preprocess(t) for t in texts]
+        return self._provider.embed_batch(processed)
+
+    def _preprocess(self, text: str) -> str:
+        """Preprocess text before embedding.
+
+        - Normalizes whitespace
+        - Truncates to max token limit
+        """
+        # Normalize whitespace
+        text = " ".join(text.split())
+
+        # Truncate if too long (8191 tokens max for OpenAI)
+        # Approximate: 4 chars per token, leave margin
+        max_chars = 30000
+        if len(text) > max_chars:
+            text = text[:max_chars]
+            logger.warning(f"Text truncated to {max_chars} characters for embedding")
+
+        return text
+
+    @property
+    def dimensions(self) -> int:
+        """Return embedding dimensions."""
+        return self._provider.dimensions
+
+    @property
+    def model_name(self) -> str:
+        """Return model identifier."""
+        return self._provider.model_name
+
+
+def get_embedding_service() -> EmbeddingService:
+    """Factory function for embedding service.
+
+    Returns:
+        Configured EmbeddingService instance.
+    """
+    return EmbeddingService()

--- a/backend/apps/rag/services/search_service.py
+++ b/backend/apps/rag/services/search_service.py
@@ -1,0 +1,273 @@
+"""Search service for RAG using pgvector similarity search."""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+from django.db import connection
+
+from apps.rag.models import DocumentChunk, IndexedDocument, DocumentStatus
+from apps.rag.services.embedding_service import get_embedding_service
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractUser
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SearchResult:
+    """A single search result with relevance score."""
+
+    chunk: DocumentChunk
+    score: float
+    document: IndexedDocument
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for API response."""
+        return {
+            "chunk_id": str(self.chunk.id),
+            "document_id": str(self.document.id),
+            "content": self.chunk.content,
+            "score": round(self.score, 4),
+            "source_type": self.document.source_type,
+            "title": self.document.title,
+            "section": self.chunk.section,
+            "metadata": {
+                **self.document.metadata,
+                **self.chunk.metadata,
+            },
+        }
+
+
+class RAGSearchService:
+    """Service for semantic search over the RAG knowledge base.
+
+    Uses pgvector for efficient cosine similarity search with HNSW indexing.
+
+    Usage:
+        service = get_search_service()
+        results = service.search(
+            query="What Df values have I seen for DLA?",
+            user=request.user,
+            k=5,
+        )
+    """
+
+    def __init__(self, embedding_service=None):
+        self._embedding_service = embedding_service or get_embedding_service()
+
+    def search(
+        self,
+        query: str,
+        user: "AbstractUser",
+        k: int = 5,
+        min_score: float = 0.5,
+        source_types: list[str] | None = None,
+        include_global: bool = True,
+    ) -> list[SearchResult]:
+        """Search the knowledge base for relevant chunks.
+
+        Args:
+            query: The search query (natural language).
+            user: The user performing the search (for data isolation).
+            k: Maximum number of results to return.
+            min_score: Minimum similarity score (0-1) to include.
+            source_types: Filter by source types (simulation, analysis, etc.).
+            include_global: Include global documents (scientific literature).
+
+        Returns:
+            List of SearchResult objects sorted by relevance.
+        """
+        # Generate query embedding
+        query_embedding = self._embedding_service.embed_text(query)
+
+        # Build SQL query with pgvector
+        # Using cosine distance: 1 - (a <=> b) gives similarity
+        sql = """
+            SELECT
+                c.id as chunk_id,
+                c.content,
+                c.section,
+                c.metadata as chunk_metadata,
+                d.id as document_id,
+                d.title,
+                d.source_type,
+                d.metadata as document_metadata,
+                1 - (c.embedding <=> %s::vector) as similarity
+            FROM rag_document_chunks c
+            JOIN rag_indexed_documents d ON c.document_id = d.id
+            WHERE d.status = %s
+            AND (
+                (d.owner_id = %s AND d.is_global = false)
+                OR (d.is_global = true AND %s = true)
+            )
+        """
+        params: list[Any] = [
+            str(query_embedding),
+            DocumentStatus.READY,
+            str(user.id),
+            include_global,
+        ]
+
+        # Add source type filter
+        if source_types:
+            placeholders = ", ".join(["%s"] * len(source_types))
+            sql += f" AND d.source_type IN ({placeholders})"
+            params.extend(source_types)
+
+        sql += """
+            ORDER BY similarity DESC
+            LIMIT %s
+        """
+        params.append(k * 2)  # Fetch extra for filtering by min_score
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+
+        # Convert to SearchResult objects
+        results: list[SearchResult] = []
+        seen_documents: set[str] = set()
+
+        for row in rows:
+            similarity = float(row[8])
+            if similarity < min_score:
+                continue
+
+            document_id = str(row[4])
+
+            # Optionally deduplicate by document
+            # (uncomment if you want max 1 chunk per document)
+            # if document_id in seen_documents:
+            #     continue
+            # seen_documents.add(document_id)
+
+            # Fetch full objects
+            try:
+                chunk = DocumentChunk.objects.get(id=row[0])
+                document = IndexedDocument.objects.get(id=row[4])
+            except (DocumentChunk.DoesNotExist, IndexedDocument.DoesNotExist):
+                continue
+
+            results.append(
+                SearchResult(
+                    chunk=chunk,
+                    score=similarity,
+                    document=document,
+                )
+            )
+
+            if len(results) >= k:
+                break
+
+        logger.info(
+            f"RAG search for '{query[:50]}...' returned {len(results)} results"
+        )
+        return results
+
+    def search_simulations(
+        self,
+        query: str,
+        user: "AbstractUser",
+        k: int = 5,
+        algorithm: str | None = None,
+    ) -> list[SearchResult]:
+        """Search specifically for simulation results.
+
+        Args:
+            query: The search query.
+            user: The user performing the search.
+            k: Maximum results.
+            algorithm: Filter by specific algorithm.
+
+        Returns:
+            List of SearchResult objects from simulations only.
+        """
+        results = self.search(
+            query=query,
+            user=user,
+            k=k,
+            source_types=["simulation"],
+            include_global=False,
+        )
+
+        # Additional filtering by algorithm if specified
+        if algorithm:
+            results = [
+                r
+                for r in results
+                if r.document.metadata.get("algorithm", "").lower()
+                == algorithm.lower()
+            ]
+
+        return results
+
+    def search_analyses(
+        self,
+        query: str,
+        user: "AbstractUser",
+        k: int = 5,
+    ) -> list[SearchResult]:
+        """Search specifically for FRAKTAL analysis results.
+
+        Args:
+            query: The search query.
+            user: The user performing the search.
+            k: Maximum results.
+
+        Returns:
+            List of SearchResult objects from analyses only.
+        """
+        return self.search(
+            query=query,
+            user=user,
+            k=k,
+            source_types=["analysis"],
+            include_global=False,
+        )
+
+    def search_scientific(
+        self,
+        query: str,
+        k: int = 5,
+    ) -> list[SearchResult]:
+        """Search scientific documentation (global documents only).
+
+        This method searches global documents without user context,
+        useful for finding literature references.
+
+        Args:
+            query: The search query.
+            k: Maximum results.
+
+        Returns:
+            List of SearchResult objects from scientific docs.
+        """
+        # For global search, we need a user context but filter to global only
+        # This is a bit awkward but maintains the API contract
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        system_user = User.objects.filter(is_superuser=True).first()
+
+        if not system_user:
+            logger.warning("No superuser found for global search")
+            return []
+
+        return self.search(
+            query=query,
+            user=system_user,
+            k=k,
+            source_types=["scientific_doc", "uploaded"],
+            include_global=True,
+        )
+
+
+def get_search_service() -> RAGSearchService:
+    """Factory function for search service.
+
+    Returns:
+        Configured RAGSearchService instance.
+    """
+    return RAGSearchService()

--- a/backend/apps/rag/tasks.py
+++ b/backend/apps/rag/tasks.py
@@ -1,0 +1,498 @@
+"""Celery tasks for RAG document indexing."""
+
+import hashlib
+import logging
+from typing import Any
+
+from celery import shared_task
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def index_simulation_task(self, simulation_id: str) -> dict[str, Any]:
+    """Index a completed simulation for RAG retrieval.
+
+    This task is called automatically when a simulation completes.
+    It creates or updates the IndexedDocument and its chunks with
+    embedded vectors for semantic search.
+
+    Args:
+        simulation_id: UUID of the simulation to index.
+
+    Returns:
+        Dictionary with status and details.
+    """
+    from apps.simulations.models import Simulation, SimulationStatus
+    from apps.rag.models import (
+        IndexedDocument,
+        DocumentChunk,
+        DocumentSource,
+        DocumentStatus,
+    )
+    from apps.rag.services.embedding_service import get_embedding_service
+    from apps.rag.services.chunking import chunk_simulation_data
+
+    try:
+        simulation = Simulation.objects.select_related("project__owner").get(
+            id=simulation_id
+        )
+
+        if simulation.status != SimulationStatus.COMPLETED:
+            return {"status": "skipped", "reason": "Simulation not completed"}
+
+        # Build content for hashing
+        content = _build_simulation_content(simulation)
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
+        # Check if already indexed with same content
+        existing = IndexedDocument.objects.filter(
+            source_type=DocumentSource.SIMULATION,
+            source_id=simulation.id,
+        ).first()
+
+        if existing and existing.content_hash == content_hash:
+            return {"status": "skipped", "reason": "Already indexed, no changes"}
+
+        # Create or update document
+        if existing:
+            # Delete old chunks
+            existing.chunks.all().delete()
+            doc = existing
+        else:
+            doc = IndexedDocument.objects.create(
+                source_type=DocumentSource.SIMULATION,
+                source_id=simulation.id,
+                title=IndexedDocument._build_simulation_title(simulation),
+                owner=simulation.project.owner,
+                is_global=False,
+                content_hash="",
+            )
+
+        doc.content_hash = content_hash
+        doc.metadata = _build_simulation_metadata(simulation)
+        doc.status = DocumentStatus.PROCESSING
+        doc.save()
+
+        # Chunk the content
+        chunks = chunk_simulation_data(content, simulation)
+
+        # Generate embeddings
+        embedding_service = get_embedding_service()
+        texts = [c["content"] for c in chunks]
+        embeddings = embedding_service.embed_batch(texts)
+
+        # Create chunk records
+        chunk_objects = []
+        for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+            chunk_objects.append(
+                DocumentChunk(
+                    document=doc,
+                    content=chunk["content"],
+                    chunk_index=i,
+                    embedding=embedding,
+                    embedding_model=embedding_service.model_name,
+                    section=chunk.get("section", ""),
+                    metadata=chunk.get("metadata", {}),
+                )
+            )
+
+        DocumentChunk.objects.bulk_create(chunk_objects)
+
+        # Mark as ready
+        doc.status = DocumentStatus.READY
+        doc.indexed_at = timezone.now()
+        doc.save()
+
+        logger.info(
+            f"Indexed simulation {simulation_id}: {len(chunk_objects)} chunks"
+        )
+
+        return {
+            "status": "success",
+            "document_id": str(doc.id),
+            "chunks_created": len(chunk_objects),
+        }
+
+    except Simulation.DoesNotExist:
+        logger.error(f"Simulation {simulation_id} not found")
+        return {"status": "failed", "error": "Simulation not found"}
+
+    except Exception as e:
+        logger.exception(f"Failed to index simulation {simulation_id}")
+
+        # Mark as failed
+        IndexedDocument.objects.filter(
+            source_type=DocumentSource.SIMULATION,
+            source_id=simulation_id,
+        ).update(status=DocumentStatus.FAILED, error_message=str(e))
+
+        # Retry with exponential backoff
+        if self.request.retries < self.max_retries:
+            raise self.retry(countdown=60 * (self.request.retries + 1))
+
+        return {"status": "failed", "error": str(e)}
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def index_analysis_task(self, analysis_id: str) -> dict[str, Any]:
+    """Index a completed FRAKTAL analysis for RAG retrieval.
+
+    Args:
+        analysis_id: UUID of the analysis to index.
+
+    Returns:
+        Dictionary with status and details.
+    """
+    from apps.fractal_analysis.models import FraktalAnalysis, AnalysisStatus
+    from apps.rag.models import (
+        IndexedDocument,
+        DocumentChunk,
+        DocumentSource,
+        DocumentStatus,
+    )
+    from apps.rag.services.embedding_service import get_embedding_service
+    from apps.rag.services.chunking import chunk_analysis_data
+
+    try:
+        analysis = FraktalAnalysis.objects.select_related("project__owner").get(
+            id=analysis_id
+        )
+
+        if analysis.status != AnalysisStatus.COMPLETED:
+            return {"status": "skipped", "reason": "Analysis not completed"}
+
+        # Build content for hashing
+        content = _build_analysis_content(analysis)
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
+        # Check if already indexed
+        existing = IndexedDocument.objects.filter(
+            source_type=DocumentSource.ANALYSIS,
+            source_id=analysis.id,
+        ).first()
+
+        if existing and existing.content_hash == content_hash:
+            return {"status": "skipped", "reason": "Already indexed, no changes"}
+
+        # Create or update document
+        if existing:
+            existing.chunks.all().delete()
+            doc = existing
+        else:
+            doc = IndexedDocument.objects.create(
+                source_type=DocumentSource.ANALYSIS,
+                source_id=analysis.id,
+                title=IndexedDocument._build_analysis_title(analysis),
+                owner=analysis.project.owner,
+                is_global=False,
+                content_hash="",
+            )
+
+        doc.content_hash = content_hash
+        doc.metadata = _build_analysis_metadata(analysis)
+        doc.status = DocumentStatus.PROCESSING
+        doc.save()
+
+        # Chunk the content
+        chunks = chunk_analysis_data(content, analysis)
+
+        # Generate embeddings
+        embedding_service = get_embedding_service()
+        texts = [c["content"] for c in chunks]
+        embeddings = embedding_service.embed_batch(texts)
+
+        # Create chunk records
+        chunk_objects = []
+        for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+            chunk_objects.append(
+                DocumentChunk(
+                    document=doc,
+                    content=chunk["content"],
+                    chunk_index=i,
+                    embedding=embedding,
+                    embedding_model=embedding_service.model_name,
+                    section=chunk.get("section", ""),
+                    metadata=chunk.get("metadata", {}),
+                )
+            )
+
+        DocumentChunk.objects.bulk_create(chunk_objects)
+
+        doc.status = DocumentStatus.READY
+        doc.indexed_at = timezone.now()
+        doc.save()
+
+        logger.info(f"Indexed analysis {analysis_id}: {len(chunk_objects)} chunks")
+
+        return {
+            "status": "success",
+            "document_id": str(doc.id),
+            "chunks_created": len(chunk_objects),
+        }
+
+    except FraktalAnalysis.DoesNotExist:
+        logger.error(f"Analysis {analysis_id} not found")
+        return {"status": "failed", "error": "Analysis not found"}
+
+    except Exception as e:
+        logger.exception(f"Failed to index analysis {analysis_id}")
+
+        IndexedDocument.objects.filter(
+            source_type=DocumentSource.ANALYSIS,
+            source_id=analysis_id,
+        ).update(status=DocumentStatus.FAILED, error_message=str(e))
+
+        if self.request.retries < self.max_retries:
+            raise self.retry(countdown=60 * (self.request.retries + 1))
+
+        return {"status": "failed", "error": str(e)}
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def index_scientific_document_task(self, document_id: str) -> dict[str, Any]:
+    """Index an uploaded scientific document.
+
+    Args:
+        document_id: UUID of the IndexedDocument to process.
+
+    Returns:
+        Dictionary with status and details.
+    """
+    from apps.rag.models import IndexedDocument, DocumentChunk, DocumentStatus
+    from apps.rag.services.embedding_service import get_embedding_service
+    from apps.rag.services.chunking import chunk_scientific_document
+
+    try:
+        doc = IndexedDocument.objects.get(id=document_id)
+        doc.status = DocumentStatus.PROCESSING
+        doc.save()
+
+        # Get content from abstract or file
+        if doc.file:
+            content = _extract_text_from_file(doc.file)
+        else:
+            content = doc.abstract
+
+        if not content:
+            doc.status = DocumentStatus.FAILED
+            doc.error_message = "No content to index"
+            doc.save()
+            return {"status": "failed", "error": "No content to index"}
+
+        # Update content hash
+        doc.content_hash = hashlib.sha256(content.encode()).hexdigest()
+        doc.save()
+
+        # Delete existing chunks
+        doc.chunks.all().delete()
+
+        # Chunk with scientific document strategy
+        chunks = chunk_scientific_document(content, doc)
+
+        # Generate embeddings
+        embedding_service = get_embedding_service()
+        texts = [c["content"] for c in chunks]
+        embeddings = embedding_service.embed_batch(texts)
+
+        # Create chunks
+        chunk_objects = [
+            DocumentChunk(
+                document=doc,
+                content=chunk["content"],
+                chunk_index=i,
+                embedding=embedding,
+                embedding_model=embedding_service.model_name,
+                section=chunk.get("section", ""),
+                page_number=chunk.get("page"),
+                metadata=chunk.get("metadata", {}),
+            )
+            for i, (chunk, embedding) in enumerate(zip(chunks, embeddings))
+        ]
+
+        DocumentChunk.objects.bulk_create(chunk_objects)
+
+        doc.status = DocumentStatus.READY
+        doc.indexed_at = timezone.now()
+        doc.save()
+
+        logger.info(
+            f"Indexed scientific document {document_id}: {len(chunk_objects)} chunks"
+        )
+
+        return {"status": "success", "chunks_created": len(chunk_objects)}
+
+    except IndexedDocument.DoesNotExist:
+        logger.error(f"Document {document_id} not found")
+        return {"status": "failed", "error": "Document not found"}
+
+    except Exception as e:
+        logger.exception(f"Failed to index document {document_id}")
+
+        try:
+            doc = IndexedDocument.objects.get(id=document_id)
+            doc.status = DocumentStatus.FAILED
+            doc.error_message = str(e)
+            doc.save()
+        except IndexedDocument.DoesNotExist:
+            pass
+
+        if self.request.retries < self.max_retries:
+            raise self.retry(countdown=60 * (self.request.retries + 1))
+
+        return {"status": "failed", "error": str(e)}
+
+
+@shared_task
+def reindex_all_user_data(user_id: str) -> dict[str, Any]:
+    """Reindex all simulations and analyses for a user.
+
+    This is a manual trigger for backfilling existing data.
+
+    Args:
+        user_id: UUID of the user.
+
+    Returns:
+        Dictionary with count of queued items.
+    """
+    from django.contrib.auth import get_user_model
+    from apps.simulations.models import Simulation, SimulationStatus
+    from apps.fractal_analysis.models import FraktalAnalysis, AnalysisStatus
+
+    User = get_user_model()
+
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        return {"status": "failed", "error": "User not found"}
+
+    indexed_count = 0
+
+    # Index simulations
+    simulations = Simulation.objects.filter(
+        project__owner=user,
+        status=SimulationStatus.COMPLETED,
+    ).values_list("id", flat=True)
+
+    for sim_id in simulations:
+        index_simulation_task.delay(str(sim_id))
+        indexed_count += 1
+
+    # Index FRAKTAL analyses
+    analyses = FraktalAnalysis.objects.filter(
+        project__owner=user,
+        status=AnalysisStatus.COMPLETED,
+    ).values_list("id", flat=True)
+
+    for analysis_id in analyses:
+        index_analysis_task.delay(str(analysis_id))
+        indexed_count += 1
+
+    logger.info(f"Queued {indexed_count} items for reindexing for user {user.email}")
+
+    return {"status": "success", "queued": indexed_count}
+
+
+# Helper functions
+
+
+def _build_simulation_content(simulation) -> str:
+    """Build textual content from simulation for indexing."""
+    parts = [
+        f"Simulation: {simulation.name or 'Unnamed'}",
+        f"Algorithm: {simulation.get_algorithm_display()}",
+        f"Parameters: {_format_parameters(simulation.parameters)}",
+    ]
+
+    if simulation.metrics:
+        parts.append(f"Results: {_format_metrics(simulation.metrics)}")
+
+    return "\n\n".join(parts)
+
+
+def _build_simulation_metadata(simulation) -> dict[str, Any]:
+    """Extract metadata for filtering."""
+    return {
+        "algorithm": simulation.algorithm,
+        "n_particles": simulation.parameters.get("n_particles"),
+        "fractal_dimension": (
+            simulation.metrics.get("fractal_dimension") if simulation.metrics else None
+        ),
+        "project_id": str(simulation.project_id),
+        "created_at": simulation.created_at.isoformat(),
+    }
+
+
+def _build_analysis_content(analysis) -> str:
+    """Build textual content from analysis for indexing."""
+    parts = [
+        f"FRAKTAL Analysis: {analysis.name or 'Unnamed'}",
+        f"Model: {analysis.get_model_display()}",
+        f"Source: {analysis.get_source_type_display()}",
+    ]
+
+    if analysis.results:
+        parts.append(f"Results: {_format_analysis_results(analysis.results)}")
+
+    return "\n\n".join(parts)
+
+
+def _build_analysis_metadata(analysis) -> dict[str, Any]:
+    """Extract metadata for filtering."""
+    return {
+        "model": analysis.model,
+        "source_type": analysis.source_type,
+        "fractal_dimension": analysis.results.get("df") if analysis.results else None,
+        "project_id": str(analysis.project_id),
+        "created_at": analysis.created_at.isoformat(),
+    }
+
+
+def _format_parameters(params: dict) -> str:
+    """Format parameters as readable text."""
+    return ", ".join(f"{k}={v}" for k, v in params.items())
+
+
+def _format_metrics(metrics: dict) -> str:
+    """Format metrics as readable text."""
+    key_metrics = ["fractal_dimension", "radius_of_gyration", "porosity", "prefactor"]
+    parts = []
+    for key in key_metrics:
+        if key in metrics:
+            value = metrics[key]
+            if isinstance(value, float):
+                parts.append(f"{key}={value:.4f}")
+            else:
+                parts.append(f"{key}={value}")
+    return ", ".join(parts)
+
+
+def _format_analysis_results(results: dict) -> str:
+    """Format analysis results as readable text."""
+    key_results = ["df", "rg", "npo", "kf"]
+    parts = []
+    for key in key_results:
+        if key in results:
+            value = results[key]
+            if isinstance(value, float):
+                parts.append(f"{key}={value:.4f}")
+            else:
+                parts.append(f"{key}={value}")
+    return ", ".join(parts)
+
+
+def _extract_text_from_file(file) -> str:
+    """Extract text from uploaded file.
+
+    Currently supports plain text files.
+    TODO: Add PDF extraction with pypdf or similar.
+    """
+    try:
+        content = file.read()
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="ignore")
+        return content
+    except Exception as e:
+        logger.warning(f"Failed to extract text from file: {e}")
+        return ""

--- a/backend/apps/simulations/tasks.py
+++ b/backend/apps/simulations/tasks.py
@@ -1232,6 +1232,13 @@ def run_simulation_task(self, simulation_id: str) -> dict:
         # Create notification for user
         create_simulation_notification(simulation, success=True)
 
+        # Index simulation for RAG knowledge base
+        try:
+            from apps.rag.tasks import index_simulation_task
+            index_simulation_task.delay(str(simulation.id))
+        except Exception as e:
+            logger.warning(f"Failed to queue RAG indexing for simulation {simulation_id}: {e}")
+
         return {
             "status": "completed",
             "simulation_id": simulation_id,

--- a/backend/apps/simulations/tasks.py
+++ b/backend/apps/simulations/tasks.py
@@ -1232,12 +1232,12 @@ def run_simulation_task(self, simulation_id: str) -> dict:
         # Create notification for user
         create_simulation_notification(simulation, success=True)
 
-        # Index simulation for RAG knowledge base
-        try:
-            from apps.rag.tasks import index_simulation_task
-            index_simulation_task.delay(str(simulation.id))
-        except Exception as e:
-            logger.warning(f"Failed to queue RAG indexing for simulation {simulation_id}: {e}")
+        # TODO: Enable RAG indexing when pgvector is available (see docs/RAG_IMPLEMENTATION_STATUS.md)
+        # try:
+        #     from apps.rag.tasks import index_simulation_task
+        #     index_simulation_task.delay(str(simulation.id))
+        # except Exception as e:
+        #     logger.warning(f"Failed to queue RAG indexing for simulation {simulation_id}: {e}")
 
         return {
             "status": "completed",

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -58,6 +58,7 @@ LOCAL_APPS = [
     "apps.simulations",
     "apps.fractal_analysis",
     "apps.ai_assistant",
+    "apps.rag",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
@@ -243,3 +244,13 @@ AI_DEFAULT_PROVIDER = config("AI_DEFAULT_PROVIDER", default="anthropic")
 AI_DEFAULT_MODEL = config("AI_DEFAULT_MODEL", default="claude-sonnet-4-20250514")
 AI_MAX_TOKENS = config("AI_MAX_TOKENS", default=4096, cast=int)
 AI_TIMEOUT_SECONDS = config("AI_TIMEOUT_SECONDS", default=60, cast=int)
+
+# RAG (Retrieval-Augmented Generation) Settings
+OPENAI_API_KEY = config("OPENAI_API_KEY", default="")
+RAG_EMBEDDING_MODEL = config("RAG_EMBEDDING_MODEL", default="text-embedding-3-small")
+RAG_EMBEDDING_DIMENSIONS = config("RAG_EMBEDDING_DIMENSIONS", default=1536, cast=int)
+RAG_CHUNK_SIZE = config("RAG_CHUNK_SIZE", default=2000, cast=int)
+RAG_CHUNK_OVERLAP = config("RAG_CHUNK_OVERLAP", default=200, cast=int)
+RAG_MAX_SEARCH_RESULTS = config("RAG_MAX_SEARCH_RESULTS", default=5, cast=int)
+RAG_MIN_SIMILARITY_SCORE = config("RAG_MIN_SIMILARITY_SCORE", default=0.5, cast=float)
+RAG_AUTO_INDEX_ON_COMPLETION = config("RAG_AUTO_INDEX_ON_COMPLETION", default=True, cast=bool)

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -58,7 +58,7 @@ LOCAL_APPS = [
     "apps.simulations",
     "apps.fractal_analysis",
     "apps.ai_assistant",
-    "apps.rag",
+    # "apps.rag",  # TODO: Enable when pgvector is available (see docs/RAG_IMPLEMENTATION_STATUS.md)
 ]
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
     "openai>=1.50",
     "cryptography>=43.0",
     "jsonschema>=4.20.0",
+    # RAG dependencies
+    "pgvector>=0.3.0",
+    "langchain-text-splitters>=0.0.1",
 ]
 
 [project.optional-dependencies]

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,31 @@
+# Postgres 17 with pgvector extension for Fly.io
+# Based on flyio/postgres-flex with pgvector installed
+
+FROM flyio/postgres-flex:17.2
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        postgresql-server-dev-17 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install pgvector
+WORKDIR /tmp
+RUN git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git && \
+    cd pgvector && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf pgvector
+
+# Clean up build dependencies to reduce image size
+RUN apt-get purge -y --auto-remove \
+        git \
+        build-essential \
+        postgresql-server-dev-17 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /

--- a/docker/postgres/fly.toml
+++ b/docker/postgres/fly.toml
@@ -1,0 +1,8 @@
+# fly.toml for postgres with pgvector
+# This is used only to build the custom image
+
+app = "pyaglogen3d-db-pgvector"
+primary_region = "mad"
+
+[build]
+  dockerfile = "Dockerfile"

--- a/docs/RAG_IMPLEMENTATION_STATUS.md
+++ b/docs/RAG_IMPLEMENTATION_STATUS.md
@@ -1,0 +1,169 @@
+# RAG Implementation Status
+
+**Status**: PAUSED - Awaiting pgvector-enabled PostgreSQL
+**Branch**: `feature/rag-implementation`
+**PR**: #45
+**Last Updated**: 2026-02-28
+
+## What's Done (100% Code Complete)
+
+All RAG code is implemented and ready. Only the database extension is missing.
+
+### Files Created
+
+```
+backend/apps/rag/
+├── __init__.py
+├── apps.py
+├── models.py                    # IndexedDocument, DocumentChunk with VectorField
+├── admin.py                     # Admin interface with reindex actions
+├── tasks.py                     # Celery indexing tasks
+├── services/
+│   ├── __init__.py
+│   ├── embedding_service.py     # OpenAI text-embedding-3-small
+│   ├── chunking.py              # Domain-specific chunking strategies
+│   └── search_service.py        # pgvector similarity search
+├── migrations/
+│   └── 0001_initial.py          # pgvector extension + models + HNSW index
+└── management/commands/
+    ├── backfill_rag_index.py    # Index existing simulations/analyses
+    └── seed_scientific_docs.py  # Seed DLA/CCA/fractal documentation
+```
+
+### Files Modified
+
+- `backend/pyproject.toml` - Added pgvector, langchain-text-splitters
+- `backend/config/settings/base.py` - Added RAG settings and apps.rag
+- `backend/apps/simulations/tasks.py` - Auto-index on simulation completion
+- `backend/apps/fractal_analysis/tasks.py` - Auto-index on analysis completion
+- `backend/apps/ai_assistant/tools/rag_tools.py` - 3 RAG tools for AI
+- `backend/apps/ai_assistant/tools/registration.py` - Registered RAG tools
+- `backend/apps/ai_assistant/views.py` - Updated system prompt
+
+### Custom Postgres Dockerfile (Optional)
+
+```
+docker/postgres/
+├── Dockerfile      # postgres-flex + pgvector v0.8.0
+└── fly.toml        # Build config
+```
+
+## What's Blocking
+
+**pgvector extension not available on Fly.io self-managed Postgres**
+
+The current `pyaglogen3d-db` uses `flyio/postgres-flex:17.2` which does NOT include pgvector.
+
+Error when running migrations:
+```
+psycopg.errors.FeatureNotSupported: extension "vector" is not available
+DETAIL: Could not open extension control file "/usr/share/postgresql/17/extension/vector.control"
+```
+
+## Options to Resume
+
+### Option 1: Fly.io Managed Postgres (MPG) - $38/month
+- Has pgvector built-in
+- Create with: `fly mpg create --name pyaglogen3d-mpg --plan development --region fra`
+- Migrate data from old database
+- Attach to API app
+
+### Option 2: External PostgreSQL with pgvector
+- **Supabase** (Free tier available, has pgvector)
+- **Neon** (Free tier available, has pgvector)
+- **Railway** (Has pgvector)
+- Update DATABASE_URL secret on Fly.io
+
+### Option 3: Custom Docker Image for postgres-flex
+- Build image with pgvector from `docker/postgres/Dockerfile`
+- Push to Docker Hub
+- Update Fly.io machine to use custom image
+- Complex but keeps current infrastructure
+
+## Resume Steps
+
+1. **Choose a pgvector-enabled PostgreSQL option** (see above)
+
+2. **If using new database, migrate data**:
+   ```bash
+   # Export from old
+   fly postgres connect -a pyaglogen3d-db
+   \copy (SELECT * FROM ...) TO '/tmp/export.csv'
+
+   # Import to new
+   fly mpg connect --cluster NEW_CLUSTER_ID
+   \copy table FROM '/tmp/export.csv'
+   ```
+
+3. **Update DATABASE_URL secret**:
+   ```bash
+   fly secrets set DATABASE_URL="postgresql://..." -a pyaglogen3d-api
+   ```
+
+4. **Run migrations**:
+   ```bash
+   fly ssh console -a pyaglogen3d-api -C "python manage.py migrate"
+   ```
+
+5. **Seed scientific documentation**:
+   ```bash
+   fly ssh console -a pyaglogen3d-api -C "python manage.py seed_scientific_docs --sync"
+   ```
+
+6. **Backfill existing data**:
+   ```bash
+   fly ssh console -a pyaglogen3d-api -C "python manage.py backfill_rag_index"
+   ```
+
+7. **Add OPENAI_API_KEY** (if not already set):
+   ```bash
+   fly secrets set OPENAI_API_KEY="sk-..." -a pyaglogen3d-api
+   ```
+
+8. **Test RAG**:
+   - Open AI chat in the app
+   - Ask: "Search my simulations for DLA with high fractal dimension"
+   - The AI should use `search_knowledge_base` tool
+
+## RAG Features When Complete
+
+### AI Tools Available
+- `search_knowledge_base` - Semantic search across user data and scientific docs
+- `get_simulation_insights` - Aggregated statistics from past simulations
+- `get_analysis_insights` - Aggregated statistics from past analyses
+
+### Auto-Indexing
+- Simulations indexed automatically when completed
+- Analyses indexed automatically when completed
+- Scientific documentation seeded via management command
+
+### Data Isolation
+- User data only visible to owner
+- Scientific docs (`is_global=True`) visible to all users
+- pgvector HNSW index for fast similarity search
+
+## Architecture
+
+```
+User Query → AI Assistant → search_knowledge_base tool
+                                    ↓
+                          Embed query (OpenAI)
+                                    ↓
+                          pgvector similarity search
+                                    ↓
+                          Return relevant chunks
+                                    ↓
+                          AI uses context in response
+```
+
+## Cost Considerations
+
+| Option | Monthly Cost | Notes |
+|--------|-------------|-------|
+| Fly.io MPG Development | $38 | Simplest, built-in pgvector |
+| Supabase Free | $0 | 500MB storage, good for dev |
+| Supabase Pro | $25 | 8GB storage, production ready |
+| Neon Free | $0 | Limited compute, good for dev |
+| Custom Docker | $0* | Uses existing Fly Postgres, complex setup |
+
+*Custom Docker requires no additional cost but needs image building and deployment.


### PR DESCRIPTION
## Summary
- Implement complete RAG (Retrieval-Augmented Generation) system for AI assistant
- **STATUS: DISABLED** - pgvector extension not available on Fly.io self-managed Postgres

## What's Implemented (Code Complete)
- IndexedDocument and DocumentChunk models with pgvector VectorField
- OpenAI text-embedding-3-small embedding service
- pgvector similarity search service with user data isolation
- Celery tasks for auto-indexing simulations/analyses
- RAG tools: search_knowledge_base, get_simulation_insights, get_analysis_insights
- Management commands: backfill_rag_index, seed_scientific_docs
- Admin interface for document management

## What's Disabled
- `apps.rag` commented out from INSTALLED_APPS
- RAG auto-indexing commented out in simulation/analysis tasks
- RAG tools registration commented out

## To Resume
See `docs/RAG_IMPLEMENTATION_STATUS.md` for detailed instructions. Options:
1. **Fly.io Managed Postgres** ($38/month) - has pgvector built-in
2. **Supabase/Neon** (free tier) - external PostgreSQL with pgvector
3. **Custom Docker image** - build postgres-flex with pgvector

## Test plan
- [x] Deploy without RAG (app works normally)
- [ ] Enable RAG when pgvector available
- [ ] Run migrations
- [ ] Seed scientific docs
- [ ] Test AI knowledge base search

🤖 Generated with [Claude Code](https://claude.com/claude-code)