### PR TITLE
feat(import): add CSV import for agglomerate geometry

### DIFF
--- a/backend/apps/simulations/models.py
+++ b/backend/apps/simulations/models.py
@@ -17,6 +17,7 @@ class SimulationAlgorithm(models.TextChoices):
     GCCA = "gcca", "Generalized CCA (Tomchuk)"
     BOX_RFA = "box_rfa", "Box-Counting RFA"
     LIMITING = "limiting", "Limiting Case Geometry"
+    IMPORTED = "imported", "Imported Geometry"
 
 
 class SimulationStatus(models.TextChoices):

--- a/backend/apps/simulations/serializers.py
+++ b/backend/apps/simulations/serializers.py
@@ -1,10 +1,11 @@
 """Simulation serializers."""
+import base64
 import random
 
 from rest_framework import serializers
 
 from .models import ParametricStudy, Simulation
-from .utils import generate_simulation_name
+from .utils import CSVParseError, generate_simulation_name, parse_csv_geometry
 
 
 def generate_seed():
@@ -17,6 +18,11 @@ class SimulationSerializer(serializers.ModelSerializer):
 
     seed = serializers.IntegerField(required=False, default=generate_seed)
     name = serializers.CharField(required=False, allow_blank=True, max_length=255)
+    csv_data = serializers.CharField(
+        required=False,
+        write_only=True,
+        help_text="Base64-encoded CSV data with x, y, z, radius columns (for 'imported' algorithm)",
+    )
 
     class Meta:
         model = Simulation
@@ -35,6 +41,7 @@ class SimulationSerializer(serializers.ModelSerializer):
             "created_at",
             "started_at",
             "completed_at",
+            "csv_data",
         ]
         read_only_fields = [
             "id",
@@ -51,11 +58,47 @@ class SimulationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         """Auto-generate name if not provided."""
+        # Remove csv_data from validated_data before creating (it's handled in the view)
+        validated_data.pop("csv_data", None)
+
         if not validated_data.get("name"):
             validated_data["name"] = generate_simulation_name(
                 validated_data.get("algorithm", "unknown")
             )
         return super().create(validated_data)
+
+    def validate(self, data):
+        """Cross-field validation."""
+        algorithm = data.get("algorithm") or self.initial_data.get("algorithm")
+
+        # For imported algorithm, csv_data is required
+        if algorithm == "imported":
+            if "csv_data" not in self.initial_data:
+                raise serializers.ValidationError(
+                    {"csv_data": "CSV data is required for imported algorithm"}
+                )
+
+        return data
+
+    def validate_csv_data(self, value: str) -> str:
+        """Validate CSV data format and content."""
+        if not value:
+            return value
+
+        # Decode base64
+        try:
+            csv_bytes = base64.b64decode(value)
+            csv_text = csv_bytes.decode("utf-8")
+        except Exception as e:
+            raise serializers.ValidationError(f"Invalid base64 encoding: {e}")
+
+        # Validate CSV structure using our utility function
+        try:
+            parse_csv_geometry(csv_text)
+        except CSVParseError as e:
+            raise serializers.ValidationError(str(e))
+
+        return value
 
     def validate_parameters(self, value: dict) -> dict:
         """Validate algorithm-specific parameters."""
@@ -83,6 +126,11 @@ class SimulationSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     "n_particles must be at least 1 for limiting cases"
                 )
+
+        elif algorithm == "imported":
+            # Imported algorithm has minimal parameter requirements
+            # Parameters will be populated by the view after parsing CSV
+            pass
 
         return value
 

--- a/backend/apps/simulations/tasks.py
+++ b/backend/apps/simulations/tasks.py
@@ -902,6 +902,261 @@ def run_box_counting_if_configured(simulation_id: str) -> dict | None:
     return box_counting_results
 
 
+def fit_power_law_rg(
+    n_values: list[int], rg_values: list[float], rp: float = 1.0
+) -> tuple[float, float, float]:
+    """Fit power-law relationship N = kf * (Rg/rp)^Df to get Df and kf.
+
+    Args:
+        n_values: List of particle counts
+        rg_values: List of corresponding Rg values
+        rp: Primary particle radius
+
+    Returns:
+        Tuple of (Df, kf, R²)
+    """
+    if len(n_values) < 3 or len(rg_values) < 3:
+        return 0.0, 0.0, 0.0
+
+    # Filter out invalid values
+    valid = [(n, rg) for n, rg in zip(n_values, rg_values) if n > 0 and rg > 0]
+    if len(valid) < 3:
+        return 0.0, 0.0, 0.0
+
+    n_arr = np.array([v[0] for v in valid], dtype=np.float64)
+    rg_arr = np.array([v[1] for v in valid], dtype=np.float64)
+
+    # Take log: log(N) = log(kf) + Df * log(Rg/rp)
+    log_n = np.log(n_arr)
+    log_rg_rp = np.log(rg_arr / rp)
+
+    # Linear fit: y = a + b*x where y=log(N), x=log(Rg/rp), b=Df, a=log(kf)
+    # Using least squares
+    A = np.vstack([log_rg_rp, np.ones(len(log_rg_rp))]).T
+    try:
+        result = np.linalg.lstsq(A, log_n, rcond=None)
+        df, log_kf = result[0]
+        kf = math.exp(log_kf)
+
+        # R² calculation
+        residuals = log_n - (df * log_rg_rp + log_kf)
+        ss_res = np.sum(residuals**2)
+        ss_tot = np.sum((log_n - np.mean(log_n)) ** 2)
+        r_squared = 1.0 - (ss_res / ss_tot) if ss_tot > 0 else 0.0
+
+        return float(df), float(kf), float(r_squared)
+    except Exception:
+        return 0.0, 0.0, 0.0
+
+
+def compute_import_metrics(
+    coords: np.ndarray, radii: np.ndarray
+) -> dict:
+    """Compute all metrics for imported geometry.
+
+    Similar to compute_limiting_metrics but also estimates Df/kf from Rg evolution.
+
+    Args:
+        coords: Particle coordinates (N x 3)
+        radii: Particle radii (N,)
+
+    Returns:
+        Dictionary with all computed metrics
+    """
+    n_particles = len(coords)
+    if n_particles == 0:
+        return {
+            "fractal_dimension": 0.0,
+            "fractal_dimension_std": 0.0,
+            "prefactor": 0.0,
+            "radius_of_gyration": 0.0,
+            "porosity": 0.0,
+            "coordination": {"mean": 0.0, "std": 0.0},
+            "rg_evolution": [],
+            "anisotropy": 1.0,
+            "asphericity": 0.0,
+            "acylindricity": 0.0,
+            "principal_moments": [0.0, 0.0, 0.0],
+            "principal_axes": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        }
+
+    # Use mean radius for calculations
+    mean_radius = float(np.mean(radii))
+
+    # Center of mass (mass-weighted for polydisperse)
+    masses = radii**3  # Mass proportional to volume
+    total_mass = masses.sum()
+    cdg = (coords.T @ masses / total_mass) if total_mass > 0 else coords.mean(axis=0)
+    centered = coords - cdg
+
+    # Radius of gyration (mass-weighted)
+    r_sq = np.sum(centered**2, axis=1)
+    rg = math.sqrt(np.sum(masses * r_sq) / total_mass) if total_mass > 0 else 0.0
+
+    # Porosity calculation
+    particle_volumes = (4.0 / 3.0) * math.pi * radii**3
+    total_particle_volume = particle_volumes.sum()
+    effective_radius = rg + mean_radius
+    aggregate_volume = (4.0 / 3.0) * math.pi * (effective_radius ** 3)
+    porosity = max(0.0, 1.0 - total_particle_volume / aggregate_volume) if aggregate_volume > 0 else 0.0
+
+    # Coordination numbers
+    coordinations = []
+    for i in range(n_particles):
+        count = 0
+        for j in range(n_particles):
+            if i != j:
+                dist = np.linalg.norm(coords[i] - coords[j])
+                touching_dist = (radii[i] + radii[j]) * 1.05  # 5% tolerance
+                if dist <= touching_dist:
+                    count += 1
+        coordinations.append(count)
+    coord_mean = float(np.mean(coordinations))
+    coord_std = float(np.std(coordinations))
+
+    # Inertia tensor (mass-weighted)
+    inertia = np.zeros((3, 3))
+    for k, coord in enumerate(centered):
+        m = masses[k]
+        r2 = np.dot(coord, coord)
+        inertia += m * (r2 * np.eye(3) - np.outer(coord, coord))
+    inertia /= total_mass if total_mass > 0 else 1.0
+
+    # Principal moments and axes
+    eigenvalues, eigenvectors = np.linalg.eigh(inertia)
+    idx = np.argsort(eigenvalues)
+    eigenvalues = eigenvalues[idx]
+    eigenvectors = eigenvectors[:, idx]
+
+    # Shape descriptors
+    I1, I2, I3 = eigenvalues
+    anisotropy = float(I3 / I1) if I1 > 1e-10 else 1.0
+    asphericity = float(I3 - 0.5 * (I1 + I2))
+    acylindricity = float(I2 - I1)
+
+    # Rg evolution for power-law fitting
+    n_values = []
+    rg_values = []
+    step = max(1, n_particles // 100)
+    for n in range(10, n_particles + 1, step):
+        subset_masses = masses[:n]
+        subset_total = subset_masses.sum()
+        if subset_total > 0:
+            subset_cdg = (coords[:n].T @ subset_masses / subset_total)
+            subset_centered = coords[:n] - subset_cdg
+            subset_r_sq = np.sum(subset_centered**2, axis=1)
+            subset_rg = math.sqrt(np.sum(subset_masses * subset_r_sq) / subset_total)
+            n_values.append(n)
+            rg_values.append(subset_rg)
+
+    # Fit Df and kf from Rg evolution
+    df, kf, r_squared = fit_power_law_rg(n_values, rg_values, mean_radius)
+
+    # Estimate Df uncertainty based on R²
+    df_std = 0.1 * (1.0 - r_squared) if r_squared > 0.5 else 0.5
+
+    return {
+        "fractal_dimension": df,
+        "fractal_dimension_std": df_std,
+        "prefactor": kf,
+        "radius_of_gyration": float(rg),
+        "porosity": float(porosity),
+        "coordination": {
+            "mean": coord_mean,
+            "std": coord_std,
+        },
+        "rg_evolution": [float(rg) for rg in rg_values],
+        "anisotropy": anisotropy,
+        "asphericity": asphericity,
+        "acylindricity": acylindricity,
+        "principal_moments": eigenvalues.tolist(),
+        "principal_axes": eigenvectors.T.tolist(),
+    }
+
+
+@shared_task(bind=True, max_retries=1)
+def compute_import_metrics_task(self, simulation_id: str) -> dict:
+    """Compute metrics for imported geometry.
+
+    This task is used when importing agglomerate geometry from CSV files.
+    The geometry is already stored, we just need to compute the metrics.
+
+    Args:
+        simulation_id: UUID string of the simulation
+
+    Returns:
+        Dictionary with task result status and metrics
+    """
+    import time
+
+    from .models import Simulation, SimulationStatus
+
+    simulation = Simulation.objects.get(id=UUID(simulation_id))
+
+    # Update status to running
+    simulation.status = SimulationStatus.RUNNING
+    simulation.started_at = timezone.now()
+    simulation.save(update_fields=["status", "started_at"])
+
+    try:
+        start_time = time.perf_counter()
+
+        # Load geometry
+        if simulation.geometry is None:
+            raise ValueError("No geometry data found for imported simulation")
+
+        buf = io.BytesIO(simulation.geometry)
+        geometry_array = np.load(buf)
+        coords = np.ascontiguousarray(geometry_array[:, :3])
+        radii = np.ascontiguousarray(geometry_array[:, 3])
+
+        # Compute metrics
+        metrics = compute_import_metrics(coords, radii)
+
+        execution_time_ms = int((time.perf_counter() - start_time) * 1000)
+
+        # Update simulation
+        simulation.metrics = metrics
+        simulation.execution_time_ms = execution_time_ms
+        simulation.engine_version = "python-import"
+        simulation.status = SimulationStatus.COMPLETED
+        simulation.completed_at = timezone.now()
+        simulation.save()
+
+        logger.info(
+            f"Import metrics computed for simulation {simulation_id}: "
+            f"Df={metrics['fractal_dimension']:.3f}, "
+            f"Rg={metrics['radius_of_gyration']:.2f}, "
+            f"time={execution_time_ms}ms"
+        )
+
+        # Create notification
+        create_simulation_notification(simulation, success=True)
+
+        return {
+            "status": "completed",
+            "simulation_id": simulation_id,
+            "fractal_dimension": metrics["fractal_dimension"],
+            "radius_of_gyration": metrics["radius_of_gyration"],
+            "execution_time_ms": execution_time_ms,
+        }
+
+    except Exception as e:
+        logger.exception(f"Import metrics computation failed: {e}")
+        simulation.status = SimulationStatus.FAILED
+        simulation.error_message = str(e)
+        simulation.completed_at = timezone.now()
+        simulation.save()
+
+        create_simulation_notification(simulation, success=False)
+
+        return {
+            "status": "failed",
+            "simulation_id": simulation_id,
+            "error": str(e),
+        }
+
+
 @shared_task(bind=True, max_retries=1)
 def run_simulation_task(self, simulation_id: str) -> dict:
     """Execute simulation using Rust engine."""

--- a/backend/apps/simulations/utils.py
+++ b/backend/apps/simulations/utils.py
@@ -1,7 +1,10 @@
 """Utility functions for simulations."""
+import csv
+import io
 from datetime import datetime
 from typing import Any
 
+import numpy as np
 from django.utils import timezone
 
 
@@ -14,6 +17,7 @@ ALGORITHM_DISPLAY_NAMES = {
     "tunable": "Tunable",
     "tunable_cc": "Tunable CC",
     "limiting": "Limiting Case",
+    "imported": "Imported",
 }
 
 # FRAKTAL model display names
@@ -255,3 +259,81 @@ def apply_sintering_config(
         params["sintering_std"] = sintering_config.get("std", 0.05)
 
     return params
+
+
+class CSVParseError(ValueError):
+    """Error raised when CSV parsing fails."""
+
+    pass
+
+
+def parse_csv_geometry(csv_text: str) -> tuple[np.ndarray, int, float, float]:
+    """Parse CSV geometry data and return particle array.
+
+    Args:
+        csv_text: CSV text content with columns: x, y, z, radius
+
+    Returns:
+        Tuple of (geometry_array, n_particles, radius_min, radius_max)
+        - geometry_array: N x 4 numpy array (x, y, z, radius)
+        - n_particles: Number of particles
+        - radius_min: Minimum particle radius
+        - radius_max: Maximum particle radius
+
+    Raises:
+        CSVParseError: If CSV format is invalid
+    """
+    try:
+        reader = csv.DictReader(io.StringIO(csv_text))
+    except Exception as e:
+        raise CSVParseError(f"Failed to parse CSV: {e}") from e
+
+    # Check for required columns (case-insensitive)
+    if reader.fieldnames is None:
+        raise CSVParseError("CSV file appears to be empty")
+
+    fieldnames_lower = [f.strip().lower() for f in reader.fieldnames]
+    required_columns = {"x", "y", "z", "radius"}
+    missing = required_columns - set(fieldnames_lower)
+    if missing:
+        raise CSVParseError(
+            f"Missing required columns: {missing}. Found: {reader.fieldnames}"
+        )
+
+    # Map lowercase column names to actual column names
+    column_map = {}
+    for fname in reader.fieldnames:
+        lower = fname.strip().lower()
+        if lower in required_columns:
+            column_map[lower] = fname
+
+    rows = []
+    for row_num, row in enumerate(reader, start=2):  # Start at 2 (1-based + header)
+        try:
+            x = float(row[column_map["x"]])
+            y = float(row[column_map["y"]])
+            z = float(row[column_map["z"]])
+            radius = float(row[column_map["radius"]])
+
+            if radius <= 0:
+                raise CSVParseError(
+                    f"Invalid radius at row {row_num}: radius must be positive"
+                )
+
+            rows.append([x, y, z, radius])
+        except (ValueError, KeyError) as e:
+            raise CSVParseError(f"Invalid data at row {row_num}: {e}") from e
+
+    if not rows:
+        raise CSVParseError("No valid particle data found in CSV")
+
+    n_particles = len(rows)
+    if n_particles > 100000:
+        raise CSVParseError(
+            f"Maximum 100,000 particles allowed. Found: {n_particles}"
+        )
+
+    geometry = np.array(rows, dtype=np.float64)
+    radii = geometry[:, 3]
+
+    return geometry, n_particles, float(radii.min()), float(radii.max())

--- a/backend/apps/simulations/views.py
+++ b/backend/apps/simulations/views.py
@@ -26,7 +26,8 @@ from .services.projection import (
     render_projection_svg,
     create_projection_filename,
 )
-from .tasks import run_simulation_task
+from .tasks import compute_import_metrics_task, run_simulation_task
+from .utils import parse_csv_geometry
 
 logger = logging.getLogger(__name__)
 
@@ -60,9 +61,58 @@ class SimulationViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         """Create simulation and enqueue task."""
+        import base64
+
         from django.conf import settings
 
         project_id = self.kwargs.get("project_pk")
+        algorithm = serializer.validated_data.get("algorithm")
+        csv_data = self.request.data.get("csv_data")
+
+        # Handle imported algorithm differently
+        if algorithm == "imported" and csv_data:
+            # Parse CSV data
+            csv_bytes = base64.b64decode(csv_data)
+            csv_text = csv_bytes.decode("utf-8")
+            geometry_array, n_particles, radius_min, radius_max = parse_csv_geometry(
+                csv_text
+            )
+
+            # Update parameters with import metadata
+            params = serializer.validated_data.get("parameters", {})
+            params.update(
+                {
+                    "n_particles": n_particles,
+                    "radius_min": float(radius_min),
+                    "radius_max": float(radius_max),
+                    "source": "csv_import",
+                }
+            )
+
+            # Create simulation with geometry stored immediately
+            simulation = serializer.save(project_id=project_id, parameters=params)
+
+            # Store geometry as NumPy binary
+            buffer = io.BytesIO()
+            np.save(buffer, geometry_array)
+            simulation.geometry = buffer.getvalue()
+            simulation.save(update_fields=["geometry"])
+
+            # Queue metrics computation task
+            try:
+                result = compute_import_metrics_task.delay(str(simulation.id))
+                simulation.task_id = result.id
+                simulation.save(update_fields=["task_id"])
+            except Exception:
+                if settings.DEBUG:
+                    # Run synchronously in development if Celery unavailable
+                    compute_import_metrics_task(str(simulation.id))
+                else:
+                    raise
+
+            return
+
+        # Regular simulation flow
         simulation = serializer.save(project_id=project_id)
 
         # Try Celery, fall back to sync execution in development
@@ -71,7 +121,7 @@ class SimulationViewSet(viewsets.ModelViewSet):
             # Store task ID for cancellation
             simulation.task_id = result.id
             simulation.save(update_fields=["task_id"])
-        except Exception as e:
+        except Exception:
             if settings.DEBUG:
                 # Run synchronously in development if Celery unavailable
                 run_simulation_task(str(simulation.id))

--- a/frontend/src/components/forms/SimulationForm.tsx
+++ b/frontend/src/components/forms/SimulationForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -8,7 +8,7 @@ import { Select } from '@/components/ui/select'
 import { Slider } from '@/components/ui/slider'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Info } from 'lucide-react'
+import { Info, Upload, FileText, X } from 'lucide-react'
 import type { SimulationAlgorithm, CreateSimulationInput } from '@/lib/types'
 
 /**
@@ -80,6 +80,7 @@ const algorithmOptions: { value: SimulationAlgorithm; label: string }[] = [
   { value: 'gcca', label: 'Generalized CCA (Tomchuk)' },
   { value: 'box_rfa', label: 'Box-Counting RFA (Brown et al.)' },
   { value: 'limiting', label: 'Limiting Case Geometry (Reference)' },
+  { value: 'imported', label: 'Import from CSV File' },
 ]
 
 type LimitingGeometryType = 'chain' | 'plane' | 'sphere'
@@ -223,6 +224,7 @@ const algorithmDescriptions: Record<SimulationAlgorithm, string> = {
   gcca: 'Generalized CCA (Tomchuk & Avdeev 2020): Unified cluster-cluster framework with configurable split strategies. Symmetric recovers Filippov, particle-cluster recovers DLCA-like growth.',
   box_rfa: 'Box-Counting RFA (Brown et al. 2010): Grid-based fractal construction using box-counting measure directly. Creates aggregates with exact target Df through recursive grid refinement.',
   limiting: 'Reference Geometry: Deterministic canonical structures for calibration. Choose between linear chain (Df=1), hexagonal plane (Df=2), or compact sphere (Df=3).',
+  imported: 'Import from CSV: Load existing agglomerate geometry from a CSV file. File must contain columns: x, y, z, radius (one particle per row). Metrics will be computed automatically.',
 }
 
 /**
@@ -587,14 +589,21 @@ export function SimulationForm({ onSubmit, isLoading }: SimulationFormProps) {
   const [algorithm, setAlgorithm] = useState<SimulationAlgorithm>('dla')
   const [params, setParams] = useState<FormParams>(defaultParams)
   const [seed, setSeed] = useState<string>('')
+  const [csvFile, setCsvFile] = useState<File | null>(null)
+  const [csvError, setCsvError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleAlgorithmChange = (value: SimulationAlgorithm) => {
     setAlgorithm(value)
+    // Clear CSV file when switching away from imported
+    if (algorithm === 'imported' && value !== 'imported') {
+      clearCsvFile()
+    }
     // Set sensible defaults when switching algorithms
     if (value === 'limiting') {
       // Default to N=7 (first complete hexagonal ring) for limiting case
       updateParam('n_particles', 7)
-    } else if (params.n_particles < 10) {
+    } else if (value !== 'imported' && params.n_particles < 10) {
       // Reset to default if coming from limiting case with small N
       updateParam('n_particles', 1000)
     }
@@ -604,8 +613,73 @@ export function SimulationForm({ onSubmit, isLoading }: SimulationFormProps) {
     setParams((prev) => ({ ...prev, [key]: value }))
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    setCsvError(null)
+
+    if (!file) {
+      setCsvFile(null)
+      return
+    }
+
+    // Validate file type
+    if (!file.name.toLowerCase().endsWith('.csv')) {
+      setCsvError('Please select a CSV file')
+      setCsvFile(null)
+      return
+    }
+
+    // Validate file size (max 10MB)
+    if (file.size > 10 * 1024 * 1024) {
+      setCsvError('File size must be less than 10MB')
+      setCsvFile(null)
+      return
+    }
+
+    setCsvFile(file)
+  }
+
+  const clearCsvFile = () => {
+    setCsvFile(null)
+    setCsvError(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+
+    // Handle imported algorithm separately
+    if (algorithm === 'imported') {
+      if (!csvFile) {
+        setCsvError('Please select a CSV file to import')
+        return
+      }
+
+      // Read file and convert to base64
+      const reader = new FileReader()
+      reader.onload = () => {
+        const result = reader.result as string
+        // Extract base64 data (remove data:...;base64, prefix)
+        const base64Data = result.split(',')[1]
+
+        onSubmit({
+          name: name.trim() || undefined,
+          algorithm: 'imported',
+          parameters: {
+            original_filename: csvFile.name,
+          },
+          seed: seed ? parseInt(seed) : undefined,
+          csv_data: base64Data,
+        } as CreateSimulationInput)
+      }
+      reader.onerror = () => {
+        setCsvError('Failed to read file')
+      }
+      reader.readAsDataURL(csvFile)
+      return
+    }
 
     // Build algorithm-specific parameters
     // Backend uses dimensionless units (radius ~1.0), we store nm for display
@@ -728,14 +802,87 @@ export function SimulationForm({ onSubmit, isLoading }: SimulationFormProps) {
         </CardContent>
       </Card>
 
+      {/* CSV File Upload (only for imported algorithm) */}
+      {algorithm === 'imported' && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Import CSV File</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="csv_file">CSV File</Label>
+              <div className="flex gap-2">
+                <Input
+                  ref={fileInputRef}
+                  id="csv_file"
+                  type="file"
+                  accept=".csv"
+                  onChange={handleFileChange}
+                  className="flex-1"
+                />
+                {csvFile && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={clearCsvFile}
+                    title="Clear file"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+              {csvError && (
+                <p className="text-sm text-destructive">{csvError}</p>
+              )}
+            </div>
+
+            {csvFile && (
+              <div className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                <FileText className="h-8 w-8 text-muted-foreground" />
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium truncate">{csvFile.name}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {(csvFile.size / 1024).toFixed(1)} KB
+                  </p>
+                </div>
+              </div>
+            )}
+
+            <div className="p-3 bg-primary/5 rounded-lg space-y-2">
+              <div className="flex items-center gap-2">
+                <Info className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">CSV Format</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                The CSV file must contain columns: <code className="bg-muted px-1 rounded">x</code>,{' '}
+                <code className="bg-muted px-1 rounded">y</code>,{' '}
+                <code className="bg-muted px-1 rounded">z</code>,{' '}
+                <code className="bg-muted px-1 rounded">radius</code> (one particle per row).
+                Maximum 100,000 particles. Headers are required.
+              </p>
+              <p className="text-xs text-muted-foreground mt-2">
+                Example:
+              </p>
+              <pre className="text-xs bg-muted p-2 rounded font-mono">
+{`x,y,z,radius
+0.0,0.0,0.0,1.0
+2.0,0.0,0.0,1.0
+4.0,0.0,0.0,1.0`}
+              </pre>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Common Parameters */}
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">Parameters</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Number of Particles - hidden for limiting case and box_rfa (particle count determined by algorithm) */}
-          {algorithm !== 'limiting' && algorithm !== 'box_rfa' && (
+          {/* Number of Particles - hidden for limiting case, box_rfa, and imported (particle count determined by algorithm/file) */}
+          {algorithm !== 'limiting' && algorithm !== 'box_rfa' && algorithm !== 'imported' && (
             <div className="space-y-2">
               <Label htmlFor="n_particles">Number of Particles</Label>
               <Input
@@ -752,8 +899,8 @@ export function SimulationForm({ onSubmit, isLoading }: SimulationFormProps) {
             </div>
           )}
 
-          {/* Sticking Probability - hidden for limiting, tunable, fracval, gcca, and box_rfa cases */}
-          {!['limiting', 'tunable', 'tunable_cc', 'fracval', 'gcca', 'box_rfa'].includes(algorithm) && (
+          {/* Sticking Probability - hidden for limiting, tunable, fracval, gcca, box_rfa, and imported cases */}
+          {!['limiting', 'tunable', 'tunable_cc', 'fracval', 'gcca', 'box_rfa', 'imported'].includes(algorithm) && (
             <div className="space-y-2">
               <Label>
                 Sticking Probability: {params.sticking_probability.toFixed(2)}
@@ -771,25 +918,27 @@ export function SimulationForm({ onSubmit, isLoading }: SimulationFormProps) {
             </div>
           )}
 
-          {/* Primary Particle Radius in nm */}
-          <div className="space-y-2">
-            <Label htmlFor="primary_radius">Primary Particle Radius (nm)</Label>
-            <Input
-              id="primary_radius"
-              type="number"
-              min={1}
-              max={1000}
-              step={1}
-              value={params.primary_particle_radius_nm}
-              onChange={(e) => updateParam('primary_particle_radius_nm', parseFloat(e.target.value) || 25.0)}
-            />
-            <p className="text-xs text-muted-foreground">
-              Physical size of primary particles. Results (Rg, coordinates) will be displayed in nm.
-            </p>
-          </div>
+          {/* Primary Particle Radius in nm - hidden for imported (uses file data) */}
+          {algorithm !== 'imported' && (
+            <div className="space-y-2">
+              <Label htmlFor="primary_radius">Primary Particle Radius (nm)</Label>
+              <Input
+                id="primary_radius"
+                type="number"
+                min={1}
+                max={1000}
+                step={1}
+                value={params.primary_particle_radius_nm}
+                onChange={(e) => updateParam('primary_particle_radius_nm', parseFloat(e.target.value) || 25.0)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Physical size of primary particles. Results (Rg, coordinates) will be displayed in nm.
+              </p>
+            </div>
+          )}
 
-          {/* Polydisperse Section - hidden for limiting, fracval (uses geometric_std), gcca, and box_rfa */}
-          {!['limiting', 'fracval', 'gcca', 'box_rfa'].includes(algorithm) && (
+          {/* Polydisperse Section - hidden for limiting, fracval (uses geometric_std), gcca, box_rfa, and imported */}
+          {!['limiting', 'fracval', 'gcca', 'box_rfa', 'imported'].includes(algorithm) && (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <Label>Size Distribution</Label>
@@ -855,8 +1004,8 @@ export function SimulationForm({ onSubmit, isLoading }: SimulationFormProps) {
           </div>
           )}
 
-          {/* Sintering Section - hidden for limiting, fracval, gcca, and box_rfa cases */}
-          {!['limiting', 'fracval', 'gcca', 'box_rfa'].includes(algorithm) && (
+          {/* Sintering Section - hidden for limiting, fracval, gcca, box_rfa, and imported cases */}
+          {!['limiting', 'fracval', 'gcca', 'box_rfa', 'imported'].includes(algorithm) && (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -3,7 +3,7 @@
  */
 
 // Enums
-export type SimulationAlgorithm = 'dla' | 'cca' | 'ballistic' | 'ballistic_cc' | 'tunable' | 'tunable_cc' | 'fracval' | 'gcca' | 'box_rfa' | 'limiting'
+export type SimulationAlgorithm = 'dla' | 'cca' | 'ballistic' | 'ballistic_cc' | 'tunable' | 'tunable_cc' | 'fracval' | 'gcca' | 'box_rfa' | 'limiting' | 'imported'
 export type SimulationStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
 export type FractalMethod = 'box_counting' | 'sandbox' | 'correlation' | 'lacunarity' | 'multifractal' | 'fraktal_granulated_2012' | 'fraktal_voxel_2018'
 export type AnalysisStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
@@ -148,7 +148,15 @@ export interface FracvalParams {
   max_placement_attempts?: number
 }
 
-export type SimulationParams = DlaParams | CcaParams | BallisticParams | TunableParams | TunableCcParams | FracvalParams | GccaParams | BoxRfaParams | LimitingParams
+export interface ImportedParams {
+  original_filename: string
+  n_particles?: number      // Set by server after parsing
+  radius_min?: number       // Set by server after parsing
+  radius_max?: number       // Set by server after parsing
+  source?: 'csv_import'     // Set by server
+}
+
+export type SimulationParams = DlaParams | CcaParams | BallisticParams | TunableParams | TunableCcParams | FracvalParams | GccaParams | BoxRfaParams | LimitingParams | ImportedParams
 
 // Simulation
 export interface SimulationSummary {
@@ -218,6 +226,13 @@ export interface CreateSimulationInput {
   algorithm: SimulationAlgorithm
   parameters: SimulationParams
   seed?: number
+  csv_data?: string  // Base64-encoded CSV data (for 'imported' algorithm)
+}
+
+export interface CreateImportedSimulationInput extends Omit<CreateSimulationInput, 'parameters'> {
+  algorithm: 'imported'
+  parameters: ImportedParams
+  csv_data: string  // Base64-encoded CSV data
 }
 
 // Image Analysis


### PR DESCRIPTION
## Summary
- Add ability to import agglomerate geometry from CSV files (x, y, z, radius columns)
- Compute all morphological metrics automatically (Df, kf, Rg, porosity, coordination, anisotropy)
- New `imported` algorithm type that integrates with existing simulation workflow

## Changes

### Backend
- Add `IMPORTED` algorithm type to `SimulationAlgorithm` enum
- Add `parse_csv_geometry()` utility with validation (column headers, 100k particle limit)
- Add `csv_data` field to serializer with base64 decoding/validation
- Handle CSV import in `perform_create` view
- Add `compute_import_metrics_task` Celery task for async metrics computation
- Implement power-law fit for Df/kf estimation from Rg evolution

### Frontend
- Add `imported` to `SimulationAlgorithm` type
- Add file upload UI with CSV format preview
- Handle base64 encoding on submit

## Test plan
- [ ] Upload valid CSV file with x, y, z, radius columns
- [ ] Verify metrics are computed correctly (compare with known geometry)
- [ ] Test error handling for invalid CSV (missing columns, bad values)
- [ ] Verify >100k particles rejected with appropriate error
- [ ] Check imported simulations appear in project list like generated ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)