### PR TITLE
build(deploy): add production Docker stack and env templates for Easypanel

### DIFF
--- a/DEPLOY_EASYPANEL.md
+++ b/DEPLOY_EASYPANEL.md
@@ -1,0 +1,98 @@
+# Deploy en Easypanel / VPS
+
+Guía mínima para este branch (`build/easypanel-deploy`) usando `docker-compose.prod.yml`.
+
+## 1. Crear los archivos reales de entorno
+
+Estos archivos NO se versionan y SON obligatorios:
+
+- `backend/.env`
+- `frontend/.env`
+
+```bash
+cp backend/.env.template backend/.env
+cp frontend/.env.template frontend/.env
+```
+
+### Importante
+
+- `backend/.env` lo consumen `db`, `backend`, `worker` y `beat`.
+- `frontend/.env` se usa en build-time para Next.js. Si cambiás `NEXT_PUBLIC_API_URL`, tenés que reconstruir la imagen del frontend.
+
+Si vas a levantar con Docker Compose en la VPS, exportá primero ambas variables de entorno para que Compose también pueda interpolar `NEXT_PUBLIC_API_URL` durante el build:
+
+```bash
+set -a
+. backend/.env
+. frontend/.env
+set +a
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+## 2. Variables mínimas
+
+### `backend/.env`
+
+Verificá especialmente:
+
+- `SECRET_KEY`
+- `DATABASE_URL`
+- `POSTGRES_DB`
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `ALLOWED_HOSTS`
+- `CSRF_TRUSTED_ORIGINS`
+- `CORS_ORIGINS`
+- `FRONTEND_URL`
+
+`DATABASE_URL` debe coincidir con las credenciales `POSTGRES_*` del mismo archivo.
+
+### `frontend/.env`
+
+Variable clave:
+
+- `NEXT_PUBLIC_API_URL`
+
+Ejemplos válidos:
+
+- Subdominios separados: `https://api.tudominio.com/api/v1`
+- Mismo dominio con proxy por path: `https://app.tudominio.com/api/v1`
+
+## 3. Routing / proxy esperado
+
+### Opción recomendada: subdominios separados
+
+- Frontend → `frontend:3000`
+- Backend API → `backend:8080`
+
+Ejemplo público:
+
+- `https://app.tudominio.com` → servicio frontend
+- `https://api.tudominio.com` → servicio backend
+- `NEXT_PUBLIC_API_URL=https://api.tudominio.com/api/v1`
+
+### Opción alternativa: mismo dominio con path proxy
+
+- `/` → frontend
+- `/api/` → backend
+- `NEXT_PUBLIC_API_URL=https://app.tudominio.com/api/v1`
+
+Si usás esta opción, el proxy de Easypanel/Nginx tiene que reenviar `/api/` al backend sin romper el prefijo.
+
+## 4. Primer deploy: migraciones
+
+Después del primer `up -d --build`, corré migraciones antes de dar por válido el deploy:
+
+```bash
+docker compose -f docker-compose.prod.yml exec backend python manage.py migrate
+```
+
+Opcional:
+
+```bash
+docker compose -f docker-compose.prod.yml exec backend python manage.py createsuperuser
+```
+
+## 5. Nota sobre healthcheck del backend
+
+La imagen del backend trae un `HEALTHCHECK` hacia `/api/v1/health/`, pero esa ruta no existe hoy en Django. En este compose se desactiva explícitamente para evitar falsos negativos en Easypanel/VPS.

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -2,9 +2,10 @@
 # pyAgloGen3D Backend Environment Variables
 # 
 # Copy this file to .env and fill in the values:
-#   cp .env.template .env
+#   cp backend/.env.template backend/.env
 #
 # NEVER commit .env to version control!
+# This file is used by db, backend, worker and beat in docker-compose.prod.yml
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -28,12 +29,13 @@ CSRF_TRUSTED_ORIGINS=https://pyaglogen.flowplanapp.com
 # -----------------------------------------------------------------------------
 
 # Full connection URL (used by Django)
-DATABASE_URL=postgresql://user:pass@db:5432/pyaglogen3d
+# Keep this aligned with POSTGRES_DB / POSTGRES_USER / POSTGRES_PASSWORD below
+DATABASE_URL=postgresql://pyaglogen3d:change-me@db:5432/pyaglogen3d
 
-# Individual credentials (used by PostgreSQL container)
+# Individual credentials (used by PostgreSQL container from this same file)
 POSTGRES_DB=pyaglogen3d
-POSTGRES_USER=
-POSTGRES_PASSWORD=
+POSTGRES_USER=pyaglogen3d
+POSTGRES_PASSWORD=change-me
 
 # -----------------------------------------------------------------------------
 # Redis (Cache + Celery Broker)

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -1,0 +1,87 @@
+# =============================================================================
+# pyAgloGen3D Backend Environment Variables
+# 
+# Copy this file to .env and fill in the values:
+#   cp .env.template .env
+#
+# NEVER commit .env to version control!
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Django Core
+# -----------------------------------------------------------------------------
+
+# Generate with: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+SECRET_KEY=
+
+# Set to false in production
+DEBUG=false
+
+# Comma-separated list of allowed hosts
+ALLOWED_HOSTS=pyaglogen.flowplanapp.com
+
+# Comma-separated list of trusted origins for CSRF
+CSRF_TRUSTED_ORIGINS=https://pyaglogen.flowplanapp.com
+
+# -----------------------------------------------------------------------------
+# Database (PostgreSQL with pgvector)
+# -----------------------------------------------------------------------------
+
+# Full connection URL (used by Django)
+DATABASE_URL=postgresql://user:pass@db:5432/pyaglogen3d
+
+# Individual credentials (used by PostgreSQL container)
+POSTGRES_DB=pyaglogen3d
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+
+# -----------------------------------------------------------------------------
+# Redis (Cache + Celery Broker)
+# -----------------------------------------------------------------------------
+
+REDIS_URL=redis://redis:6379/0
+
+# -----------------------------------------------------------------------------
+# CORS & Frontend
+# -----------------------------------------------------------------------------
+
+# Comma-separated list of allowed CORS origins
+CORS_ORIGINS=https://pyaglogen.flowplanapp.com
+
+# Frontend URL for links in emails, etc.
+FRONTEND_URL=https://pyaglogen.flowplanapp.com
+
+# -----------------------------------------------------------------------------
+# AI Configuration
+# -----------------------------------------------------------------------------
+
+# Encryption key for storing AI API keys securely
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+AI_ENCRYPTION_KEY=
+
+# Default AI provider and model
+AI_DEFAULT_PROVIDER=anthropic
+AI_DEFAULT_MODEL=claude-sonnet-4-20250514
+AI_MAX_TOKENS=4096
+AI_TIMEOUT_SECONDS=60
+
+# OpenAI API Key (optional - RAG currently disabled)
+# OPENAI_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Email (SMTP)
+# -----------------------------------------------------------------------------
+
+EMAIL_HOST=
+EMAIL_PORT=587
+EMAIL_USE_TLS=true
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+DEFAULT_FROM_EMAIL=
+
+# -----------------------------------------------------------------------------
+# Monitoring (Optional)
+# -----------------------------------------------------------------------------
+
+# Sentry DSN for error tracking
+# SENTRY_DSN=

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,153 @@
+# =============================================================================
+# Production Docker Compose for pyAgloGen3D
+# 
+# Services: db (pgvector), redis, backend, worker, beat, frontend
+# 
+# Usage:
+#   docker compose -f docker-compose.prod.yml build
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# Ports:
+#   - Backend API: 8004 (internal 8080) → pyaglogen.flowplanapp.com
+#   - Frontend:    3001 (internal 3000) → pyaglogen.flowplanapp.com
+# =============================================================================
+
+services:
+  # ---------------------------------------------------------------------------
+  # Database: PostgreSQL 16 with pgvector extension
+  # ---------------------------------------------------------------------------
+  db:
+    build:
+      context: ./docker/postgres
+      dockerfile: Dockerfile.prod
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - backend/.env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-pyaglogen3d}
+      POSTGRES_USER: ${POSTGRES_USER:-pyaglogen3d}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-pyaglogen3d} -d ${POSTGRES_DB:-pyaglogen3d}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Redis: Cache and Celery broker
+  # ---------------------------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Backend: Django + Gunicorn (API server)
+  # ---------------------------------------------------------------------------
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    ports:
+      - "8004:8080"
+    env_file:
+      - backend/.env
+    command: >
+      gunicorn
+      --bind 0.0.0.0:8080
+      --workers 2
+      --timeout 120
+      --access-logfile -
+      --error-logfile -
+      config.wsgi:application
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Worker: Celery background task processor
+  # ---------------------------------------------------------------------------
+  worker:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file:
+      - backend/.env
+    command: celery -A config worker -l info --concurrency=2
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Beat: Celery periodic task scheduler
+  # ---------------------------------------------------------------------------
+  beat:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file:
+      - backend/.env
+    command: celery -A config beat -l info
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Frontend: Next.js standalone server
+  # ---------------------------------------------------------------------------
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3000"
+    env_file:
+      - frontend/.env
+    depends_on:
+      - backend
+    networks:
+      - app-network
+    restart: unless-stopped
+
+# =============================================================================
+# Networks
+# =============================================================================
+networks:
+  app-network:
+    driver: bridge
+
+# =============================================================================
+# Volumes
+# =============================================================================
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,12 +24,8 @@ services:
       - postgres_data:/var/lib/postgresql/data
     env_file:
       - backend/.env
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB:-pyaglogen3d}
-      POSTGRES_USER: ${POSTGRES_USER:-pyaglogen3d}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-pyaglogen3d} -d ${POSTGRES_DB:-pyaglogen3d}"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -79,6 +75,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      disable: true
     networks:
       - app-network
     restart: unless-stopped
@@ -128,6 +126,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:?set NEXT_PUBLIC_API_URL before building frontend}
     ports:
       - "3001:3000"
     env_file:

--- a/docker/postgres/Dockerfile.prod
+++ b/docker/postgres/Dockerfile.prod
@@ -1,0 +1,37 @@
+# =============================================================================
+# PostgreSQL 16 with pgvector extension for Docker Compose production
+# Based on official postgres image with pgvector compiled from source
+# =============================================================================
+
+FROM postgres:16-bookworm
+
+# Install build dependencies for pgvector
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        postgresql-server-dev-16 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install pgvector
+WORKDIR /tmp
+RUN git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git && \
+    cd pgvector && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf pgvector
+
+# Clean up build dependencies
+RUN apt-get purge -y --auto-remove \
+        build-essential \
+        git \
+        postgresql-server-dev-16 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+
+# Enable pgvector extension on database creation
+# This script runs after the database is initialized
+COPY init-pgvector.sql /docker-entrypoint-initdb.d/

--- a/docker/postgres/init-pgvector.sql
+++ b/docker/postgres/init-pgvector.sql
@@ -1,0 +1,4 @@
+-- Enable pgvector extension
+-- This script runs automatically when the database container initializes
+
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -2,9 +2,11 @@
 # pyAgloGen3D Frontend Environment Variables
 #
 # Copy this file to .env and fill in the values:
-#   cp .env.template .env
+#   cp frontend/.env.template frontend/.env
 #
 # NEVER commit .env to version control!
+# Next.js reads this at build time for production bundles.
+# If NEXT_PUBLIC_API_URL changes, rebuild the frontend image.
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -12,7 +14,10 @@
 # -----------------------------------------------------------------------------
 
 # Backend API URL (must be accessible from browser)
-NEXT_PUBLIC_API_URL=https://pyaglogen.flowplanapp.com/api/v1
+# Examples:
+# - https://api.example.com/api/v1
+# - https://app.example.com/api/v1  (if your proxy forwards /api to backend)
+NEXT_PUBLIC_API_URL=https://api.example.com/api/v1
 
 # -----------------------------------------------------------------------------
 # Environment

--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -1,0 +1,21 @@
+# =============================================================================
+# pyAgloGen3D Frontend Environment Variables
+#
+# Copy this file to .env and fill in the values:
+#   cp .env.template .env
+#
+# NEVER commit .env to version control!
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# API Configuration
+# -----------------------------------------------------------------------------
+
+# Backend API URL (must be accessible from browser)
+NEXT_PUBLIC_API_URL=https://pyaglogen.flowplanapp.com/api/v1
+
+# -----------------------------------------------------------------------------
+# Environment
+# -----------------------------------------------------------------------------
+
+NODE_ENV=production

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,69 @@
+# =============================================================================
+# Multi-stage Dockerfile for pyAgloGen3D Frontend
+# Next.js 14 standalone build optimized for production
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Stage 1: Dependencies
+# -----------------------------------------------------------------------------
+FROM node:18-alpine AS deps
+
+RUN apk add --no-cache libc6-compat
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json package-lock.json* ./
+
+# Install dependencies
+RUN npm ci --ignore-scripts
+
+# -----------------------------------------------------------------------------
+# Stage 2: Build
+# -----------------------------------------------------------------------------
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependencies from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Build the application
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# -----------------------------------------------------------------------------
+# Stage 3: Production runner
+# -----------------------------------------------------------------------------
+FROM node:18-alpine AS runner
+
+WORKDIR /app
+
+# Set production environment
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create non-root user for security
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy public folder
+COPY --from=builder /app/public ./public
+
+# Copy standalone build
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# Switch to non-root user
+USER nextjs
+
+# Expose port
+EXPOSE 3000
+
+# Set hostname and port for Next.js standalone
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# Start the server
+CMD ["node", "server.js"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,6 +25,9 @@ FROM node:18-alpine AS builder
 
 WORKDIR /app
 
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .


### PR DESCRIPTION
## Summary
- add a production Docker stack definition and env templates to prepare VPS/Easypanel deployment
- include frontend and postgres production Docker assets needed by the stack
- keep deployment infrastructure changes isolated from unrelated local working tree noise