### PR TITLE
fix(frontend): correct projection ZIP batch defaults and surface download errors

### DIFF
--- a/frontend/src/app/projects/[id]/simulations/[simId]/page.tsx
+++ b/frontend/src/app/projects/[id]/simulations/[simId]/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useProject } from '@/hooks/useProjects'
 import { useSimulation, useSimulationGeometry, useNeighborGraph } from '@/hooks/useSimulations'
-import { simulationsApi } from '@/lib/api'
+import { ApiError, simulationsApi } from '@/lib/api'
 import { Header } from '@/components/layout/Header'
 import { AgglomerateViewer } from '@/components/viewer3d/AgglomerateViewer'
 import { ViewerControls } from '@/components/viewer3d/ViewerControls'
@@ -23,6 +23,7 @@ import { BoxCountingAnalysis, LimitingCasesCard, LIMITING_CASES, OpticalProperti
 import type { LimitingCaseLine } from '@/components/charts/FractalPlot'
 import { LoadingScreen } from '@/components/common/LoadingSpinner'
 import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft, Clock, Download, Hash, Settings, StopCircle, Trash2 } from 'lucide-react'
 import { formatNumber } from '@/lib/utils'
@@ -59,6 +60,7 @@ export default function SimulationDetailPage({
   })
   const [isProjectionLoading, setIsProjectionLoading] = useState(false)
   const [isBatchLoading, setIsBatchLoading] = useState(false)
+  const [batchDownloadError, setBatchDownloadError] = useState<string | null>(null)
   const [isExporting, setIsExporting] = useState(false)
   const [showLimitingCases, setShowLimitingCases] = useState(false)
 
@@ -117,6 +119,7 @@ export default function SimulationDetailPage({
 
   const handleBatchDownload = async (params: BatchParams) => {
     setIsBatchLoading(true)
+    setBatchDownloadError(null)
     try {
       const blob = await simulationsApi.getProjectionBatch(id, simId, params)
       // Trigger download
@@ -130,6 +133,11 @@ export default function SimulationDetailPage({
       URL.revokeObjectURL(url)
     } catch (err) {
       console.error('Failed to generate batch projections:', err)
+      setBatchDownloadError(
+        err instanceof ApiError
+          ? err.message
+          : 'Failed to generate projections ZIP. Verify the selected angles and try again.'
+      )
     } finally {
       setIsBatchLoading(false)
     }
@@ -531,12 +539,19 @@ export default function SimulationDetailPage({
                 />
               </div>
               <div className="lg:col-span-1">
-                <ProjectionControls
-                  onPreview={handleProjectionPreview}
-                  onDownloadBatch={handleBatchDownload}
-                  isLoading={isProjectionLoading}
-                  isBatchLoading={isBatchLoading}
-                />
+                <div className="space-y-4">
+                  {batchDownloadError && (
+                    <Alert variant="destructive">
+                      <AlertDescription>{batchDownloadError}</AlertDescription>
+                    </Alert>
+                  )}
+                  <ProjectionControls
+                    onPreview={handleProjectionPreview}
+                    onDownloadBatch={handleBatchDownload}
+                    isLoading={isProjectionLoading}
+                    isBatchLoading={isBatchLoading}
+                  />
+                </div>
               </div>
             </div>
 

--- a/frontend/src/components/projection/ProjectionControls.tsx
+++ b/frontend/src/components/projection/ProjectionControls.tsx
@@ -55,7 +55,7 @@ export function ProjectionControls({
   const [azEnd, setAzEnd] = useState(150)
   const [azStep, setAzStep] = useState(30)
   const [elStart, setElStart] = useState(0)
-  const [elEnd, setElEnd] = useState(150)
+  const [elEnd, setElEnd] = useState(90)
   const [elStep, setElStep] = useState(30)
 
   const handlePreview = () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,7 +23,7 @@ import { authApi } from './auth-api'
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
 
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(
     message: string,
     public status: number,
@@ -247,14 +247,25 @@ export const simulationsApi = {
           azimuth_end: params.azimuth_end ?? 150,
           azimuth_step: params.azimuth_step ?? 30,
           elevation_start: params.elevation_start ?? 0,
-          elevation_end: params.elevation_end ?? 150,
+          elevation_end: params.elevation_end ?? 90,
           elevation_step: params.elevation_step ?? 30,
           format: params.format ?? 'png',
         }),
       }
     )
     if (!res.ok) {
-      throw new ApiError('Failed to generate projections', res.status)
+      const contentType = res.headers.get('Content-Type') || ''
+      if (contentType.includes('application/json')) {
+        const error = await res.json().catch(() => ({}))
+        throw new ApiError(
+          error.message || error.detail || 'Failed to generate projections',
+          res.status,
+          error.details
+        )
+      }
+
+      const text = await res.text().catch(() => '')
+      throw new ApiError(text || 'Failed to generate projections', res.status)
     }
     return res.blob()
   },


### PR DESCRIPTION
## Summary
- correct the batch projection defaults so ZIP export uses a valid elevation range by default
- surface backend ZIP generation errors to the user instead of silently swallowing them in the browser console
- keep the fix isolated to the projection controls, batch download API call, and simulation detail UI