### PR TITLE
fix(frontend): remove duplicate ApiError export

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -695,5 +695,3 @@ export const adminApi = {
     }),
 }
 
-// Export ApiError for error handling
-export { ApiError }


### PR DESCRIPTION
## Summary
- remove the duplicate `ApiError` export that breaks the Next.js production build
- keep the fix minimal and isolated to `frontend/src/lib/api.ts`
- supersedes the earlier noisy branch created while attempting the same hotfix