### PR TITLE
fix(frontend): align batch study algorithms with single simulation

### DIFF
--- a/frontend/src/components/batch/BatchResultsTable.tsx
+++ b/frontend/src/components/batch/BatchResultsTable.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { Label } from '@/components/ui/label'
 import { Download, ExternalLink, RefreshCw, Calculator } from 'lucide-react'
+import { getSimulationAlgorithmLabel } from '@/lib/simulation-algorithms'
 import { formatNumber } from '@/lib/utils'
 import type { ParametricStudyResults, BoxCountingResult } from '@/lib/types'
 
@@ -166,7 +167,7 @@ export function BatchResultsTable({
 
         {/* Algorithm info */}
         <div className="flex gap-4 text-sm text-muted-foreground">
-          <span>Algorithm: <span className="font-medium text-foreground">{data.base_algorithm}</span></span>
+          <span>Algorithm: <span className="font-medium text-foreground">{getSimulationAlgorithmLabel(data.base_algorithm)}</span></span>
           <span>Seeds: <span className="font-medium text-foreground">{data.progress.total / Object.values(data.parameter_grid).reduce((acc, v) => acc * (Array.isArray(v) ? v.length : 1), 1)}</span></span>
         </div>
 

--- a/frontend/src/components/batch/BatchSimulationForm.tsx
+++ b/frontend/src/components/batch/BatchSimulationForm.tsx
@@ -8,16 +8,8 @@ import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { Plus, Trash2, Play } from 'lucide-react'
+import { batchSimulationAlgorithmOptions } from '@/lib/simulation-algorithms'
 import type { SimulationAlgorithm, CreateParametricStudyInput } from '@/lib/types'
-
-const algorithmOptions = [
-  { value: 'ballistic', label: 'Ballistic Particle-Cluster' },
-  { value: 'ballistic_cc', label: 'Ballistic Cluster-Cluster' },
-  { value: 'dla', label: 'Diffusion-Limited Aggregation' },
-  { value: 'cca', label: 'Cluster-Cluster Aggregation' },
-  { value: 'tunable', label: 'Tunable Fractal Dimension' },
-  { value: 'limiting', label: 'Limiting Cases (Df=1,2,3)' },
-]
 
 const limitingGeometryOptions = [
   { value: 'chain', label: 'Linear Chain (Df=1)' },
@@ -265,19 +257,31 @@ export function BatchSimulationForm({ onSubmit, isLoading }: BatchSimulationForm
   const effectiveSeeds = algorithm === 'limiting' ? 1 : (parseInt(seedsPerCombo) || 1)
   const totalSimulations = totalCombinations * effectiveSeeds
 
-  const parameterOptions = algorithm === 'limiting'
-    ? [
+  const parameterOptions = useMemo(() => {
+    if (algorithm === 'limiting') {
+      return [
         { value: 'configuration_type', label: 'Configuration Type' },
         { value: 'n_particles', label: 'Number of Particles' },
         { value: 'sintering_coeff', label: 'Sintering Coefficient' },
         { value: 'packing', label: 'Packing Type (sphere only)' },
       ]
-    : [
-        { value: 'n_particles', label: 'Number of Particles' },
-        { value: 'sticking_probability', label: 'Sticking Probability' },
-        { value: 'target_df', label: 'Target Df (tunable only)' },
-        { value: 'target_kf', label: 'Target kf (tunable only)' },
-      ]
+    }
+
+    const options = [
+      { value: 'n_particles', label: 'Number of Particles' },
+      { value: 'target_df', label: 'Target Df' },
+    ]
+
+    if (['dla', 'cca', 'ballistic', 'ballistic_cc'].includes(algorithm)) {
+      options.splice(1, 0, { value: 'sticking_probability', label: 'Sticking Probability' })
+    }
+
+    if (['tunable', 'tunable_cc', 'fracval', 'gcca'].includes(algorithm)) {
+      options.push({ value: 'target_kf', label: 'Target kf' })
+    }
+
+    return options
+  }, [algorithm])
 
   return (
     <Card>
@@ -315,7 +319,7 @@ export function BatchSimulationForm({ onSubmit, isLoading }: BatchSimulationForm
             <Select
               value={algorithm}
               onChange={(e) => setAlgorithm(e.target.value as SimulationAlgorithm)}
-              options={algorithmOptions}
+              options={batchSimulationAlgorithmOptions}
             />
           </div>
 

--- a/frontend/src/components/forms/SimulationForm.tsx
+++ b/frontend/src/components/forms/SimulationForm.tsx
@@ -9,6 +9,10 @@ import { Slider } from '@/components/ui/slider'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Info, Upload, FileText, X } from 'lucide-react'
+import {
+  singleSimulationAlgorithmOptions,
+  simulationAlgorithmDescriptions,
+} from '@/lib/simulation-algorithms'
 import type { SimulationAlgorithm, CreateSimulationInput } from '@/lib/types'
 
 /**
@@ -68,20 +72,6 @@ interface SimulationFormProps {
   onSubmit: (data: CreateSimulationInput) => void
   isLoading?: boolean
 }
-
-const algorithmOptions: { value: SimulationAlgorithm; label: string }[] = [
-  { value: 'dla', label: 'DLA (Diffusion-Limited Aggregation)' },
-  { value: 'cca', label: 'CCA (Brownian Cluster-Cluster)' },
-  { value: 'ballistic', label: 'Ballistic PC (Particle-Cluster)' },
-  { value: 'ballistic_cc', label: 'Ballistic CC (Cluster-Cluster)' },
-  { value: 'tunable', label: 'Tunable PC (Filippov method)' },
-  { value: 'tunable_cc', label: 'Tunable CC (Cluster-Cluster)' },
-  { value: 'fracval', label: 'FracVAL (Polydisperse CC)' },
-  { value: 'gcca', label: 'Generalized CCA (Tomchuk)' },
-  { value: 'box_rfa', label: 'Box-Counting RFA (Brown et al.)' },
-  { value: 'limiting', label: 'Limiting Case Geometry (Reference)' },
-  { value: 'imported', label: 'Import from CSV File' },
-]
 
 type LimitingGeometryType = 'chain' | 'plane' | 'sphere'
 
@@ -211,20 +201,6 @@ const defaultParams: FormParams = {
   box_rfa_n_levels: 6,
   box_rfa_connectivity: 'random_walk',
   box_rfa_single_aggregate: false,  // Default: accurate Df (may have isolated particles)
-}
-
-const algorithmDescriptions: Record<SimulationAlgorithm, string> = {
-  dla: 'Diffusion-Limited Aggregation: Particles undergo random walks and stick upon contact. Produces fractal structures with Df ~ 2.4-2.6.',
-  cca: 'Brownian CCA: Clusters move via Brownian motion and merge on collision. Produces open structures with Df ~ 1.8-2.0.',
-  ballistic: 'Ballistic PC: Particles travel in straight lines towards a growing cluster. Produces denser structures with Df ~ 2.8-3.0.',
-  ballistic_cc: 'Ballistic CC: Clusters travel in straight lines and merge on collision. Produces branched structures with Df ~ 1.8-2.2 (thesis section 6.2).',
-  tunable: 'Tunable PC (Filippov method): Generate aggregates with target fractal dimension and prefactor. Based on N = kf × (Rg/rp)^Df power law.',
-  tunable_cc: 'Tunable CC (Cluster-Cluster): Similar to Tunable PC but merges clusters instead of single particles. Produces more realistic aggregates with controlled Df and kf.',
-  fracval: 'FracVAL (Morán et al. 2019): Polydisperse cluster-cluster aggregation with lognormal size distribution. Adaptive pairing strategy ensures Df and kf control for each aggregate.',
-  gcca: 'Generalized CCA (Tomchuk & Avdeev 2020): Unified cluster-cluster framework with configurable split strategies. Symmetric recovers Filippov, particle-cluster recovers DLCA-like growth.',
-  box_rfa: 'Box-Counting RFA (Brown et al. 2010): Grid-based fractal construction using box-counting measure directly. Creates aggregates with exact target Df through recursive grid refinement.',
-  limiting: 'Reference Geometry: Deterministic canonical structures for calibration. Choose between linear chain (Df=1), hexagonal plane (Df=2), or compact sphere (Df=3).',
-  imported: 'Import from CSV: Load existing agglomerate geometry from a CSV file. File must contain columns: x, y, z, radius (one particle per row). Metrics will be computed automatically.',
 }
 
 /**
@@ -794,10 +770,10 @@ export function SimulationForm({ onSubmit, isLoading }: SimulationFormProps) {
           <Select
             value={algorithm}
             onChange={(e) => handleAlgorithmChange(e.target.value as SimulationAlgorithm)}
-            options={algorithmOptions}
+            options={singleSimulationAlgorithmOptions}
           />
           <p className="text-sm text-muted-foreground">
-            {algorithmDescriptions[algorithm]}
+            {simulationAlgorithmDescriptions[algorithm]}
           </p>
         </CardContent>
       </Card>

--- a/frontend/src/lib/simulation-algorithms.ts
+++ b/frontend/src/lib/simulation-algorithms.ts
@@ -1,0 +1,109 @@
+import type { SimulationAlgorithm } from '@/lib/types'
+
+export interface SimulationAlgorithmMetadata {
+  value: SimulationAlgorithm
+  label: string
+  description: string
+  supportsSingle: boolean
+  supportsBatch: boolean
+}
+
+export const simulationAlgorithms: SimulationAlgorithmMetadata[] = [
+  {
+    value: 'dla',
+    label: 'DLA (Diffusion-Limited Aggregation)',
+    description: 'Diffusion-Limited Aggregation: Particles undergo random walks and stick upon contact. Produces fractal structures with Df ~ 2.4-2.6.',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'cca',
+    label: 'CCA (Brownian Cluster-Cluster)',
+    description: 'Brownian CCA: Clusters move via Brownian motion and merge on collision. Produces open structures with Df ~ 1.8-2.0.',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'ballistic',
+    label: 'Ballistic PC (Particle-Cluster)',
+    description: 'Ballistic PC: Particles travel in straight lines towards a growing cluster. Produces denser structures with Df ~ 2.8-3.0.',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'ballistic_cc',
+    label: 'Ballistic CC (Cluster-Cluster)',
+    description: 'Ballistic CC: Clusters travel in straight lines and merge on collision. Produces branched structures with Df ~ 1.8-2.2 (thesis section 6.2).',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'tunable',
+    label: 'Tunable PC (Filippov method)',
+    description: 'Tunable PC (Filippov method): Generate aggregates with target fractal dimension and prefactor. Based on N = kf × (Rg/rp)^Df power law.',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'tunable_cc',
+    label: 'Tunable CC (Cluster-Cluster)',
+    description: 'Tunable CC (Cluster-Cluster): Similar to Tunable PC but merges clusters instead of single particles. Produces more realistic aggregates with controlled Df and kf.',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'fracval',
+    label: 'FracVAL (Polydisperse CC)',
+    description: 'FracVAL (Morán et al. 2019): Polydisperse cluster-cluster aggregation with lognormal size distribution. Adaptive pairing strategy ensures Df and kf control for each aggregate.',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'gcca',
+    label: 'Generalized CCA (Tomchuk)',
+    description: 'Generalized CCA (Tomchuk & Avdeev 2020): Unified cluster-cluster framework with configurable split strategies. Symmetric recovers Filippov, particle-cluster recovers DLCA-like growth.',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'box_rfa',
+    label: 'Box-Counting RFA (Brown et al.)',
+    description: 'Box-Counting RFA (Brown et al. 2010): Grid-based fractal construction using box-counting measure directly. Creates aggregates with exact target Df through recursive grid refinement.',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'limiting',
+    label: 'Limiting Case Geometry (Reference)',
+    description: 'Reference Geometry: Deterministic canonical structures for calibration. Choose between linear chain (Df=1), hexagonal plane (Df=2), or compact sphere (Df=3).',
+    supportsSingle: true,
+    supportsBatch: true,
+  },
+  {
+    value: 'imported',
+    label: 'Import from CSV File',
+    description: 'Import from CSV: Load existing agglomerate geometry from a CSV file. File must contain columns: x, y, z, radius (one particle per row). Metrics will be computed automatically.',
+    supportsSingle: true,
+    supportsBatch: false,
+  },
+]
+
+export const singleSimulationAlgorithmOptions = simulationAlgorithms
+  .filter((algorithm) => algorithm.supportsSingle)
+  .map(({ value, label }) => ({ value, label }))
+
+export const batchSimulationAlgorithmOptions = simulationAlgorithms
+  .filter((algorithm) => algorithm.supportsBatch)
+  .map(({ value, label }) => ({ value, label }))
+
+export const simulationAlgorithmDescriptions: Record<SimulationAlgorithm, string> = Object.fromEntries(
+  simulationAlgorithms.map(({ value, description }) => [value, description])
+) as Record<SimulationAlgorithm, string>
+
+export const simulationAlgorithmLabels: Record<SimulationAlgorithm, string> = Object.fromEntries(
+  simulationAlgorithms.map(({ value, label }) => [value, label])
+) as Record<SimulationAlgorithm, string>
+
+export function getSimulationAlgorithmLabel(algorithm: SimulationAlgorithm): string {
+  return simulationAlgorithmLabels[algorithm]
+}


### PR DESCRIPTION
## Summary
- centralize simulation algorithm metadata in a single frontend source of truth
- align `New Batch Study` algorithm options and labels with `New Simulation`
- include the batch-supported algorithms that were missing and keep `imported` explicitly out of batch for now