### PR TITLE
fix(accounts): surface verification email delivery failures

### DIFF
--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -2,6 +2,7 @@
 Authentication views for PyAglogen3D.
 """
 
+import logging
 import secrets
 from datetime import timedelta
 
@@ -29,6 +30,11 @@ from .serializers import (
 )
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
+
+
+class VerificationEmailDeliveryError(Exception):
+    """Raised when a verification email could not be delivered."""
 
 
 def get_tokens_for_user(user) -> dict:
@@ -55,15 +61,25 @@ class RegisterView(generics.CreateAPIView):
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
-        # Send verification email
-        self._send_verification_email(user)
+        verification_email_sent = True
+        message = "Registration successful. Please check your email to verify your account."
+
+        try:
+            self._send_verification_email(user)
+        except VerificationEmailDeliveryError:
+            verification_email_sent = False
+            message = (
+                "Registration successful, but we could not send the verification email. "
+                "Please try resending it shortly."
+            )
 
         tokens = get_tokens_for_user(user)
         return Response(
             {
                 "user": UserSerializer(user).data,
                 "tokens": tokens,
-                "message": "Registration successful. Please check your email to verify your account.",
+                "message": message,
+                "verification_email_status": "sent" if verification_email_sent else "failed",
             },
             status=status.HTTP_201_CREATED,
         )
@@ -89,10 +105,14 @@ class RegisterView(generics.CreateAPIView):
                 message=f"Click this link to verify your email: {verify_url}",
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=[user.email],
-                fail_silently=True,
+                fail_silently=False,
             )
-        except Exception:
-            pass  # Don't fail registration if email fails
+        except Exception as exc:
+            logger.exception(
+                "Failed to send verification email during registration",
+                extra={"user_id": str(user.id), "email": user.email},
+            )
+            raise VerificationEmailDeliveryError from exc
 
 
 class LoginView(APIView):
@@ -237,10 +257,20 @@ class ResendVerificationView(APIView):
             user = User.objects.get(email=email)
         except User.DoesNotExist:
             # Don't reveal if email exists
-            return Response({"message": "If this email exists, a verification link will be sent."})
+            return Response(
+                {
+                    "message": "If this email exists, a verification link will be sent.",
+                    "verification_email_status": "unknown",
+                }
+            )
 
         if user.email_verified:
-            return Response({"message": "Email is already verified."})
+            return Response(
+                {
+                    "message": "Email is already verified.",
+                    "verification_email_status": "not_required",
+                }
+            )
 
         # Invalidate old tokens
         EmailVerificationToken.objects.filter(user=user, used=False).update(used=True)
@@ -262,12 +292,27 @@ class ResendVerificationView(APIView):
                 message=f"Click this link to verify your email: {verify_url}",
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=[user.email],
-                fail_silently=True,
+                fail_silently=False,
             )
         except Exception:
-            pass
+            logger.exception(
+                "Failed to send verification email during resend",
+                extra={"user_id": str(user.id), "email": user.email},
+            )
+            return Response(
+                {
+                    "message": "We could not send the verification email. Please try again shortly.",
+                    "verification_email_status": "failed",
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
 
-        return Response({"message": "If this email exists, a verification link will be sent."})
+        return Response(
+            {
+                "message": "If this email exists, a verification link will be sent.",
+                "verification_email_status": "sent",
+            }
+        )
 
 
 class OAuthCallbackView(APIView):

--- a/backend/tests/test_auth_email_verification.py
+++ b/backend/tests/test_auth_email_verification.py
@@ -1,0 +1,120 @@
+"""Tests for email verification delivery responses."""
+
+import logging
+
+from django.contrib.auth import get_user_model
+
+from apps.accounts.models import EmailVerificationToken
+
+User = get_user_model()
+
+
+class TestRegisterEmailVerification:
+    """Tests for registration email delivery reporting."""
+
+    def test_register_reports_sent_verification_email(self, api_client, db, mocker):
+        mock_send_mail = mocker.patch("apps.accounts.views.send_mail", return_value=1)
+
+        response = api_client.post(
+            "/api/v1/auth/register/",
+            {
+                "email": "new-user@example.com",
+                "password": "StrongPassword123!",
+                "password_confirm": "StrongPassword123!",
+                "first_name": "New",
+                "last_name": "User",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["verification_email_status"] == "sent"
+        assert "Please check your email" in response.data["message"]
+        assert mock_send_mail.called is True
+        assert EmailVerificationToken.objects.filter(
+            user__email="new-user@example.com"
+        ).exists()
+
+    def test_register_reports_failed_verification_email(
+        self, api_client, db, mocker, caplog
+    ):
+        mocker.patch(
+            "apps.accounts.views.send_mail",
+            side_effect=RuntimeError("smtp unavailable"),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            response = api_client.post(
+                "/api/v1/auth/register/",
+                {
+                    "email": "broken-mail@example.com",
+                    "password": "StrongPassword123!",
+                    "password_confirm": "StrongPassword123!",
+                    "first_name": "Broken",
+                    "last_name": "Mail",
+                },
+                format="json",
+            )
+
+        assert response.status_code == 201, response.data
+        assert response.data["verification_email_status"] == "failed"
+        assert "could not send the verification email" in response.data["message"]
+        assert User.objects.filter(email="broken-mail@example.com").exists()
+        assert "Failed to send verification email during registration" in caplog.text
+
+
+class TestResendEmailVerification:
+    """Tests for resend email delivery reporting."""
+
+    def test_resend_reports_sent_verification_email(self, api_client, db, mocker):
+        user = User.objects.create_user(
+            email="pending@example.com",
+            password="StrongPassword123!",
+        )
+        mock_send_mail = mocker.patch("apps.accounts.views.send_mail", return_value=1)
+
+        response = api_client.post(
+            "/api/v1/auth/resend-verification/",
+            {"email": user.email},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.data
+        assert response.data["verification_email_status"] == "sent"
+        assert mock_send_mail.called is True
+        assert EmailVerificationToken.objects.filter(user=user, used=False).count() == 1
+
+    def test_resend_reports_failed_verification_email(
+        self, api_client, db, mocker, caplog
+    ):
+        user = User.objects.create_user(
+            email="resend-failure@example.com",
+            password="StrongPassword123!",
+        )
+        mocker.patch(
+            "apps.accounts.views.send_mail",
+            side_effect=RuntimeError("smtp unavailable"),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            response = api_client.post(
+                "/api/v1/auth/resend-verification/",
+                {"email": user.email},
+                format="json",
+            )
+
+        assert response.status_code == 503, response.data
+        assert response.data["verification_email_status"] == "failed"
+        assert "could not send the verification email" in response.data["message"]
+        assert EmailVerificationToken.objects.filter(user=user, used=False).count() == 1
+        assert "Failed to send verification email during resend" in caplog.text
+
+    def test_resend_keeps_unknown_status_for_missing_email(self, api_client, db):
+        response = api_client.post(
+            "/api/v1/auth/resend-verification/",
+            {"email": "missing@example.com"},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.data
+        assert response.data["verification_email_status"] == "unknown"


### PR DESCRIPTION
## Summary
- stop reporting false success when verification email delivery fails during register and resend flows
- expose `verification_email_status` so clients can distinguish sent / failed / unknown / not_required outcomes
- add focused backend coverage for verification email delivery states

## Notes
- This keeps `users.email_verified` as the current source of truth and does not re-architect the verification model.
- Full pytest execution in this environment is still constrained by project bootstrap/tooling (`aglogen_core` import), but the fix was kept isolated and syntax-checked.