### PR TITLE
fix(permissions): restore admin visibility of user projects [PYA-7]

### DIFF
--- a/backend/apps/accounts/permissions.py
+++ b/backend/apps/accounts/permissions.py
@@ -14,6 +14,10 @@ class IsProjectOwnerOrShared(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj) -> bool:
+        # Superusers have full access
+        if request.user.is_superuser:
+            return True
+
         # Check if obj is a project or has a project attribute
         project = getattr(obj, "project", obj)
 
@@ -42,6 +46,10 @@ class IsProjectAdmin(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj) -> bool:
+        # Superusers have full access
+        if request.user.is_superuser:
+            return True
+
         project = getattr(obj, "project", obj)
 
         # Owner is always admin

--- a/backend/apps/projects/views.py
+++ b/backend/apps/projects/views.py
@@ -22,6 +22,10 @@ class ProjectViewSet(viewsets.ModelViewSet):
         if not user.is_authenticated:
             return Project.objects.filter(is_public=True)
 
+        # Superusers can see all projects
+        if user.is_superuser:
+            return Project.objects.all()
+
         # Get IDs of projects shared with user
         shared_project_ids = ProjectShare.objects.filter(user=user).values_list(
             "project_id", flat=True

--- a/backend/apps/projects/views.py
+++ b/backend/apps/projects/views.py
@@ -22,8 +22,9 @@ class ProjectViewSet(viewsets.ModelViewSet):
         if not user.is_authenticated:
             return Project.objects.filter(is_public=True)
 
-        # Superusers can see all projects
-        if user.is_superuser:
+        # Superusers: show all projects only on detail views,
+        # list view shows only their own + shared (like normal users)
+        if user.is_superuser and self.action != "list":
             return Project.objects.all()
 
         # Get IDs of projects shared with user


### PR DESCRIPTION
## Summary
Restore admin/superuser visibility of user projects across the platform, addressing the regression described in PYA-7.

## Changes
- `fix(permissions): allow superusers to access all projects` — grants superusers cross-user visibility via permission layer
- `fix(projects): hide other users' projects from superuser dashboard` — balances the above so the main dashboard view still behaves as expected for non-admin browsing

## Context
- Addresses [PYA-7](https://jjeg1979.atlassian.net/browse/PYA-7): "Restore admin visibility of user projects and simulations"
- Commits were previously on local main (never pushed) and have now been cherry-picked to a dedicated branch following the project's PR workflow.

## Testing
- Manual verification: superuser can now see user projects from admin flow
- Normal users still cannot see other users' private data

## Notes
Rescued from a pre-cleanup snapshot. The full WIP snapshot is preserved on `rescue/main-wip-20260416` for reference.